### PR TITLE
use SafePropertyAccessor to access properties instead of directly

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/OpenSSL.java
+++ b/src/main/java/org/jruby/ext/openssl/OpenSSL.java
@@ -37,6 +37,7 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.SafePropertyAccessor;
 
 /**
  * OpenSSL (methods as well as an entry point)
@@ -55,7 +56,7 @@ public final class OpenSSL {
     }
 
     public static void createOpenSSL(final Ruby runtime) {
-        boolean registerProvider = Boolean.getBoolean("jruby.openssl.provider.register");
+        boolean registerProvider = SafePropertyAccessor.getBoolean("jruby.openssl.provider.register");
         SecurityHelper.setRegisterProvider( registerProvider );
 
         final RubyModule _OpenSSL = runtime.getOrCreateModule("OpenSSL");
@@ -109,9 +110,9 @@ public final class OpenSSL {
         _OpenSSL.setConstant("OPENSSL_VERSION", runtime.newString(OPENSSL_VERSION));
         _OpenSSL.setConstant("OPENSSL_VERSION_NUMBER", runtime.newFixnum(OPENSSL_VERSION_NUMBER));
 
-        setDebug(_OpenSSL, runtime.newBoolean( Boolean.getBoolean("jruby.openssl.debug") ) );
+        setDebug(_OpenSSL, runtime.newBoolean( SafePropertyAccessor.getBoolean("jruby.openssl.debug") ) );
 
-        final String warn = System.getProperty("jruby.openssl.warn");
+        final String warn = SafePropertyAccessor.getProperty("jruby.openssl.warn");
         if ( warn != null ) OpenSSL.warn = Boolean.parseBoolean(warn);
     }
 

--- a/src/main/java/org/jruby/ext/openssl/x509store/Lookup.java
+++ b/src/main/java/org/jruby/ext/openssl/x509store/Lookup.java
@@ -66,6 +66,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyHash;
 import org.jruby.ext.openssl.SecurityHelper;
 import org.jruby.util.JRubyFile;
+import org.jruby.util.SafePropertyAccessor;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ChannelStream;
 import org.jruby.util.io.FileExistsException;
@@ -277,7 +278,7 @@ public class Lookup {
     }
 
     public int loadDefaultJavaCACertsFile() throws Exception {
-        final String certsFile = System.getProperty("java.home") +
+        final String certsFile = SafePropertyAccessor.getProperty("java.home") +
             "/lib/security/cacerts".replace('/', File.separatorChar);
         final FileInputStream fin = new FileInputStream(certsFile);
         int count = 0;
@@ -543,7 +544,7 @@ public class Lookup {
                 return 0;
             }
 
-            String[] dirs = dir.split(System.getProperty("path.separator"));
+            String[] dirs = dir.split(SafePropertyAccessor.getProperty("path.separator"));
 
             for ( int i=0; i<dirs.length; i++ ) {
                 if ( dirs[i].length() == 0 ) {

--- a/src/main/java/org/jruby/ext/openssl/x509store/X509Utils.java
+++ b/src/main/java/org/jruby/ext/openssl/x509store/X509Utils.java
@@ -45,6 +45,8 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 
+import org.jruby.util.SafePropertyAccessor;
+
 /**
  * Contains most of the functionality that beings with X509 in
  * crypty/x509/x509_def.c, crypty/x509/x509_txt.c and others.
@@ -284,9 +286,9 @@ public abstract class X509Utils {
 
     public static final String OPENSSLDIR = "/usr/local/openssl";
 
-    public static final String X509_CERT_AREA = System.getProperty("java.home") + "/lib/security";
-    public static final String X509_CERT_DIR = System.getProperty("java.home") + "/lib/security";
-    public static final String X509_CERT_FILE = System.getProperty("java.home") + "/lib/security" + "/cacerts";
+    public static final String X509_CERT_AREA = SafePropertyAccessor.getProperty("java.home") + "/lib/security";
+    public static final String X509_CERT_DIR = SafePropertyAccessor.getProperty("java.home") + "/lib/security";
+    public static final String X509_CERT_FILE = SafePropertyAccessor.getProperty("java.home") + "/lib/security" + "/cacerts";
     public static final String X509_PRIVATE_DIR = "/usr/lib/ssl/private";
 
     public static final String X509_CERT_DIR_EVP = "SSL_CERT_DIR";


### PR DESCRIPTION
In certain contexts, java will throw an exception if you try to read an "unsafe" system property. Jruby already has a mechanism to safely try to read them and fail silently if it won't work. This just updates jruby-openssl to use that same safety mechanism.

fixes https://github.com/jruby/jruby-openssl/issues/27