### PR TITLE
try loading bouncycastle jars from classpath first, before loading direc...

### DIFF
--- a/lib/jopenssl/load.rb
+++ b/lib/jopenssl/load.rb
@@ -11,10 +11,17 @@ begin
   require_jar( 'org.bouncycastle', 'bcprov-jdk15on', version )
   bc_jars = true
 rescue LoadError
-end if defined?(Jars) && ( ! Jars.skip? ) rescue nil
+end if (defined?(Jars) && ( ! Jars.skip? ) rescue nil)
 unless bc_jars
-  load "org/bouncycastle/bcpkix-jdk15on/#{version}/bcpkix-jdk15on-#{version}.jar"
-  load "org/bouncycastle/bcprov-jdk15on/#{version}/bcprov-jdk15on-#{version}.jar"
+  begin
+    # try regular require first
+    require "bcpkix-jdk15on-#{version}.jar"
+    require "bcprov-jdk15on-#{version}.jar"
+  rescue LoadError
+    # load from here
+    load "org/bouncycastle/bcpkix-jdk15on/#{version}/bcpkix-jdk15on-#{version}.jar"
+    load "org/bouncycastle/bcprov-jdk15on/#{version}/bcprov-jdk15on-#{version}.jar"
+  end
 end
 
 require 'jruby'


### PR DESCRIPTION
...tly

Re: Issue https://github.com/jruby/jruby-openssl/issues/10

I ran into this today. The new security requirements from Oracle are extremely restrictive. One of the  things that's not allowed any more is java.net.NetPermission("specifyStreamHandler"), which means that jruby's JRubyClassLoader, which uses a custom streamhandler called CompoundJarURLStreamHandler to load jars from inside another jar, does not work.

I was able to get around this issue by, like you mentioned, putting the BC jars on the classpath (in my JNLP file directly as lib jars) and "hacking" `jopenssl/load` to try a regular `require` before the direct `load`s that it already does.

Let me know what you think. With this fix, I was actually able (finally!) to get our jruby-based app to launch again under java 1.7u51+. I'm very willing (eager, in fact) to work with you on this to get something that you like and that will work for my use case.