### PR TITLE
Use ByteList instead of StringBuilder. Fixes #33

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/HMAC.java
+++ b/src/main/java/org/jruby/ext/openssl/HMAC.java
@@ -129,7 +129,7 @@ public class HMAC extends RubyObject {
 
     private Mac mac;
     private byte[] key;
-    private final StringBuilder data = new StringBuilder(64);
+    private ByteList data = new ByteList(64);
 
     @JRubyMethod(visibility = Visibility.PRIVATE)
     public IRubyObject initialize(IRubyObject key, IRubyObject digest) {
@@ -171,21 +171,20 @@ public class HMAC extends RubyObject {
             throw getRuntime().newNotImplementedError(e.getMessage());
         }
 
-        data.setLength(0);
-        data.append( that.data );
+        data = new ByteList(that.data);
 
         return this;
     }
 
     @JRubyMethod(name = { "update", "<<" })
     public IRubyObject update(final IRubyObject obj) {
-        data.append(obj);
+        data.append(obj.asString().getByteList());
         return this;
     }
 
     @JRubyMethod
     public IRubyObject reset() {
-        data.setLength(0);
+        data = new ByteList(64);
         return this;
     }
 
@@ -205,7 +204,8 @@ public class HMAC extends RubyObject {
 
     private byte[] getSignatureBytes() {
         mac.reset();
-        return mac.doFinal( data.toString().getBytes() );
+        mac.update(data.getUnsafeBytes(), data.getBegin(), data.getRealSize());
+        return mac.doFinal();
     }
 
     private static String getDigestAlgorithmName(final IRubyObject digest) {

--- a/src/test/ruby/test_hmac.rb
+++ b/src/test/ruby/test_hmac.rb
@@ -1,4 +1,3 @@
-# coding: US-ASCII
 require File.expand_path('test_helper', File.dirname(__FILE__))
 
 class TestHMAC < TestCase
@@ -32,6 +31,8 @@ class TestHMAC < TestCase
     assert_equal('c17c7b655b11574fea8d676a1fdc0ca8', @h2.hexdigest) # calculated on MRI
     @h2.update('DATA')
     assert_equal('9e50596c0fa1197f8587443a942d8afc', @h2.hexdigest) # calculated on MRI
+    @h2.reset
+    @h2.update("\xFF") # invalid utf-8 char
+    assert_equal('0770623462e782b51bb0689a8ba4f3f1', @h2.hexdigest) # calcualted on MRI
   end
-
 end


### PR DESCRIPTION
StringBuilder append method causes rubystring conversion to java string