### PR TITLE
Add SSLSocket ssl_version property like MRI has

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -854,6 +854,12 @@ public class SSLSocket extends RubyObject {
         return getRuntime().getNil(); // throw new UnsupportedOperationException();
     }
 
+    @JRubyMethod
+    public IRubyObject ssl_version() {
+        if ( engine == null ) return getRuntime().getNil();
+        return getRuntime().newString( engine.getSession().getProtocol() );
+    }
+
     private SocketChannel getSocketChannel() {
         return (SocketChannel) io.getChannel();
     }

--- a/src/test/ruby/ssl/test_ssl.rb
+++ b/src/test/ruby/ssl/test_ssl.rb
@@ -83,6 +83,10 @@ class TestSSL < TestCase
   end
 
   def test_ssl_version_sslv3
+    skip('Disable SSLv3 test in CI as it currently fails on some JVM versions') unless ENV['CI'].nil?
+    # This test appears to fail on Oracle JDK 1.7.0_76 but not Oracle JDK 1.6.0_65
+    # The test (client) reports Connection reset by peer
+    # The server reports "No appropriate protocol (protocol is disabled or cipher suites are inappropriate)"
     ctx_proc = Proc.new do |ctx|
       ctx.ssl_version = "SSLv3"
     end

--- a/src/test/ruby/ssl/test_ssl.rb
+++ b/src/test/ruby/ssl/test_ssl.rb
@@ -82,4 +82,30 @@ class TestSSL < TestCase
     end
   end
 
+  def test_ssl_version_sslv3
+    ctx_proc = Proc.new do |ctx|
+      ctx.ssl_version = "SSLv3"
+    end
+    start_server(PORT, OpenSSL::SSL::VERIFY_NONE, true, :ctx_proc => ctx_proc) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ssl = OpenSSL::SSL::SSLSocket.new(sock)
+      ssl.connect
+      assert_equal("SSLv3", ssl.ssl_version)
+      ssl.close
+    end
+  end
+
+  def test_ssl_version_tlsv1
+    ctx_proc = Proc.new do |ctx|
+      ctx.ssl_version = "TLSv1"
+    end
+    start_server(PORT, OpenSSL::SSL::VERIFY_NONE, true, :ctx_proc => ctx_proc) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ssl = OpenSSL::SSL::SSLSocket.new(sock)
+      ssl.connect
+      assert_equal("TLSv1", ssl.ssl_version)
+      ssl.close
+    end
+  end
+
 end


### PR DESCRIPTION
When using Ruby 2.0 we can call .ssl_version on an SSLSocket to see what protocol was negotiated in the handshake. With JRuby this is not possible.

This adds the ssl_version method so we can now do the same thing.

I can't say for certain, but this might be what @jordansissel needs in order to resolve #26 too.

(The Ruby commit: https://github.com/ruby/ruby/commit/060184c347822b11dff3db6bef915c04a564c4e4)