### PR TITLE
Mimic MRI's openssl when jopenssl require fails.

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -1,1 +1,5 @@
-require 'jopenssl/load'
+begin
+  require 'jopenssl/load'
+rescue LoadError => e
+  e.message.sub! 'jopenssl/load', 'openssl'
+end


### PR DESCRIPTION
Some libraries (such as RubyGems [1]) rescues openssl load errors and
adjust their behavior depending if the openssl is properly required.
However, prior this commit, require 'openssl' succeeded just fine, but
the subsequent requires failed, which makes RubyGems (and similar) to
fail unexpectedly.

Please note that I submitted similar jruby/jruby/pull/2894 for 1.7 branch.

[1] https://github.com/rubygems/rubygems/blob/master/lib/rubygems/security.rb#L14
