### PR TITLE
Moves break inside store.is_key_entry logic

### DIFF
--- a/lib/openssl/pkcs12.rb
+++ b/lib/openssl/pkcs12.rb
@@ -72,8 +72,8 @@ module OpenSSL
                 end
             end
           end
+          break
         end
-        break
       end
     rescue java.lang.Exception => e
       raise PKCS12Error, e.inspect


### PR DESCRIPTION
This PR was in response to an issue we were running into when converting Apple .p12 files into .pem using `OpenSSL::PKCS12`.

When creating a new instance with an Apple .p12 file, the initializer was only checking the first alias in the `store` because of a break in the `.each` loop. If there is more than one alias, only the first is being checked.

In the case of our .p12 file, the SECOND alias passes `store.is_key_store`, but was being skipped because of the break.

This moves the break inside the `store.is_key_entry` logic statement, which means each alias will be iterated through until either a match is found or there are no other aliases.

If it would help, I can create a unit test to cover this use case. Didn't want to create a unit test if I'm just using this module wrong.