### PR TITLE
fix load error: jopenssl/load -- java.lang.VerifyError: Bad type on operand stack when using bouncycastle 1.51 or 1.52

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/X509Cert.java
+++ b/src/main/java/org/jruby/ext/openssl/X509Cert.java
@@ -555,7 +555,7 @@ public class X509Cert extends RubyObject {
         for ( X509Extension ext : uniqueExtensions() ) {
             try {
                 final byte[] bytes = ext.getRealValueEncoded();
-                builder.addExtension(ext.getRealObjectID(), ext.isRealCritical(), bytes);
+                builder.addExtension(ext.getRealObjectID().getId(), ext.isRealCritical(), bytes);
             }
             catch (IOException ioe) {
                 throw runtime.newIOErrorFromException(ioe);


### PR DESCRIPTION
This should fix https://github.com/jruby/jruby-openssl/issues/4

In BouncyCastle 1.51 they [changed the hierarchy of ASN1ObjectIdentifier](https://github.com/bcgit/bc-java/commit/737bedf272b4fb34c395f07addb72b28d4f90a13) so it is a parent of DERObjectIdentifier instead of a descendant of it.  In the code, if we pass a string id instead of the  ASN1ObjectIdentifier object then BouncyCastle will create the correct ASN1ObjectIdentifier object. 