### PR TITLE
Support negotiating up to TLS1_1 and TLS1_2 when the server supports these ssl_versions

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -122,13 +122,18 @@ public class SSLContext extends RubyObject {
         SSL_VERSION_OSSL2JSSE.put("SSLv23", "SSL");
         SSL_VERSION_OSSL2JSSE.put("SSLv23_server", "SSL");
         SSL_VERSION_OSSL2JSSE.put("SSLv23_client", "SSL");
-        ENABLED_PROTOCOLS.put("SSL", new String[] { "SSLv2", "SSLv3", "TLSv1" });
+
+        if ( OpenSSL.javaVersion7(true) ) { // >= 1.7
+            ENABLED_PROTOCOLS.put("SSL", new String[] { "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2" });
+        } else {
+            ENABLED_PROTOCOLS.put("SSL", new String[] { "SSLv2", "SSLv3", "TLSv1" });
+        }
 
         // Historically we were ahead of MRI to support TLS
         // ... thus the non-standard names version names :
 
         SSL_VERSION_OSSL2JSSE.put("TLS", "TLS");
-        ENABLED_PROTOCOLS.put("TLS", new String[] { "TLSv1", "TLSv1.1" });
+        ENABLED_PROTOCOLS.put("TLS", new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" });
 
         SSL_VERSION_OSSL2JSSE.put("TLSv1.1", "TLSv1.1");
         ENABLED_PROTOCOLS.put("TLSv1.1", new String[] { "TLSv1.1" });

--- a/src/test/ruby/ssl/test_helper.rb
+++ b/src/test/ruby/ssl/test_helper.rb
@@ -147,6 +147,10 @@ module SSLTestHelper
     ssl.close rescue nil
   end
 
+  def java_version
+    java.lang.System.get_property('java.version')[2].to_i
+  end
+
   TEST_KEY_RSA1024 = <<-_end_of_pem_
 -----BEGIN RSA PRIVATE KEY-----
 MIICXgIBAAKBgQDLwsSw1ECnPtT+PkOgHhcGA71nwC2/nL85VBGnRqDxOqjVh7Cx

--- a/src/test/ruby/ssl/test_ssl.rb
+++ b/src/test/ruby/ssl/test_ssl.rb
@@ -95,4 +95,33 @@ class TestSSL < TestCase
     end
   end
 
+  def test_ssl_version_tlsv1_1
+    return if java_version < 7 # TLS1_1 is not supported by JDK 6
+
+    ctx_proc = Proc.new do |ctx|
+      ctx.ssl_version = "TLSv1_1"
+    end
+    start_server(PORT, OpenSSL::SSL::VERIFY_NONE, true, :ctx_proc => ctx_proc) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ssl = OpenSSL::SSL::SSLSocket.new(sock)
+      ssl.connect
+      assert_equal("TLSv1.1", ssl.ssl_version)
+      ssl.close
+    end
+  end
+
+  def test_ssl_version_tlsv1_2
+    return if java_version < 7 # TLS1_2 is not supported by JDK 6
+
+    ctx_proc = Proc.new do |ctx|
+      ctx.ssl_version = "TLSv1_2"
+    end
+    start_server(PORT, OpenSSL::SSL::VERIFY_NONE, true, :ctx_proc => ctx_proc) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ssl = OpenSSL::SSL::SSLSocket.new(sock)
+      ssl.connect
+      assert_equal("TLSv1.2", ssl.ssl_version)
+      ssl.close
+    end
+  end
 end


### PR DESCRIPTION
This fixes an issue we were having where JRuby apps couldn't connect to a server running only with TLS1_1 and TLS1_2 enabled unless you specifically told the JRuby client to use TLS1_1 or TLS1_2.  The JRuby client would not negotiate up to the highest ssl version allowed by the server, it would always stop at TLS1.