### PR TITLE
return the same ssl_version format that is presented in OpenSSL::SSL::SSLContext::METHODS and also matches MRI

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -929,7 +929,7 @@ public class SSLSocket extends RubyObject {
     @JRubyMethod
     public IRubyObject ssl_version() {
         if ( engine == null ) return getRuntime().getNil();
-        return getRuntime().newString( engine.getSession().getProtocol() );
+        return getRuntime().newString( engine.getSession().getProtocol().replace('.', '_') );
     }
 
     private transient SocketChannelImpl socketChannel;

--- a/src/test/ruby/ssl/test_ssl.rb
+++ b/src/test/ruby/ssl/test_ssl.rb
@@ -103,7 +103,7 @@ class TestSSL < TestCase
       sock = TCPSocket.new("127.0.0.1", port)
       ssl = OpenSSL::SSL::SSLSocket.new(sock)
       ssl.connect
-      assert_equal("TLSv1.1", ssl.ssl_version)
+      assert_equal("TLSv1_1", ssl.ssl_version)
       ssl.close
     end
   end unless java6? # TLS1_1 is not supported by JDK 6
@@ -116,7 +116,7 @@ class TestSSL < TestCase
       sock = TCPSocket.new("127.0.0.1", port)
       ssl = OpenSSL::SSL::SSLSocket.new(sock)
       ssl.connect
-      assert_equal("TLSv1.2", ssl.ssl_version)
+      assert_equal("TLSv1_2", ssl.ssl_version)
       ssl.close
     end
   end unless java6? # TLS1_2 is not supported by JDK 6


### PR DESCRIPTION
According to [the comment](https://github.com/jruby/jruby-openssl/blob/master/src/main/java/org/jruby/ext/openssl/SSLContext.java#L187) for the OpenSSL::SSL::SSLContext::METHODS implementation we don't want to expose TLSv1.1 or TLSv1.2 as ssl_version options.  This change should keep those strings from coming out via the ssl_version accessor.  

NOTE: This change is backwards incompatible if anyone is currently checking the ssl_version against TLSv1.1 or TLSv1.2.