### PR TITLE
Force US locale for date formatting

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/StringHelper.java
+++ b/src/main/java/org/jruby/ext/openssl/StringHelper.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Locale;
 
 import org.jcodings.specific.UTF8Encoding;
 import org.joda.time.DateTime;
@@ -132,6 +133,7 @@ abstract class StringHelper {
 
     private static final DateTimeFormatter ASN_DATE_NO_ZONE =
         DateTimeFormat.forPattern("MMM dd HH:mm:ss yyyy") // + " zzz"
+                      .withLocale(Locale.US)
                       .withZone(DateTimeZone.UTC);
 
     static StringBuilder appendGMTDateTime(final StringBuilder text, final DateTime time) {


### PR DESCRIPTION
Otherwise it uses system locale, which is inconsistent with MRI, and leads to the following test failure on my machine (`LANG=pl_PL.UTF-8`):
```
[INFO]   2) Failure:
[INFO] test_revoked_to_text(TestX509CRL) [/home/divide/projekty/jruby-openssl/src/test/ruby/x509/test_x509crl.rb:64]:
[INFO] <"        Last Update: Jul  7 17:31:35 2014 GMT"> expected but was
[INFO] <"        Last Update: lip  7 17:31:35 2014 GMT">.
```