### PR TITLE
Adding support for auth_tag for GCM based crypto [WIP]

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/Cipher.java
+++ b/src/main/java/org/jruby/ext/openssl/Cipher.java
@@ -46,6 +46,7 @@ import static javax.crypto.Cipher.DECRYPT_MODE;
 import static javax.crypto.Cipher.ENCRYPT_MODE;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.RC2ParameterSpec;
 
 import org.jruby.Ruby;
@@ -72,6 +73,7 @@ import static org.jruby.ext.openssl.OpenSSL.*;
  */
 public class Cipher extends RubyObject {
     private static final long serialVersionUID = -5390983669951165103L;
+    private static final int GCM_AUTH_TAG_LEN = 128;
 
     private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
         public Cipher allocate(Ruby runtime, RubyClass klass) { return new Cipher(runtime, klass); }
@@ -715,6 +717,7 @@ public class Cipher extends RubyObject {
     private byte[] realIV;
     private byte[] orgIV;
     private String padding;
+    private byte[] authTag;
 
     private void dumpVars(final PrintStream out, final String header) {
         out.println(this.toString() + ' ' + header +
@@ -1039,6 +1042,12 @@ public class Cipher extends RubyObject {
                         new SimpleSecretKey("RC4", this.key)
                     );
                 }
+                else if ( "GCM".equalsIgnoreCase(cryptoMode) ) {
+                    cipher.init(encryptMode ? ENCRYPT_MODE : DECRYPT_MODE,
+                        new SimpleSecretKey(getCipherAlgorithm(), this.key),
+                        new GCMParameterSpec(GCM_AUTH_TAG_LEN, this.realIV)
+                    );
+                }
                 else {
                     cipher.init(encryptMode ? ENCRYPT_MODE : DECRYPT_MODE,
                         new SimpleSecretKey(getCipherAlgorithm(), this.key),
@@ -1120,7 +1129,7 @@ public class Cipher extends RubyObject {
         // trying to allow update after final like cruby-openssl. Bad idea.
         if ( "RC4".equalsIgnoreCase(cryptoBase) ) return runtime.newString("");
 
-        final ByteList str;
+        ByteList str;
         try {
             final byte[] out = cipher.doFinal();
             if ( out != null ) {
@@ -1131,6 +1140,11 @@ public class Cipher extends RubyObject {
                 // for now. JRUBY-3335.
                 //if ( realIV != null && encryptMode ) ...
                 if ( realIV != null ) setLastIVIfNeeded(out);
+                if ( "GCM".equalsIgnoreCase(cryptoMode) ) {
+                    int tag_size = GCM_AUTH_TAG_LEN / Byte.SIZE;
+                    this.authTag = new ByteList(str.bytes(), str.length() - tag_size, tag_size).bytes();
+                    str = new ByteList(str.bytes(), 0, str.length() - tag_size);
+                }
             }
             else {
                 str = new ByteList(ByteList.NULL_ARRAY);
@@ -1171,6 +1185,17 @@ public class Cipher extends RubyObject {
     public IRubyObject set_padding(IRubyObject padding) {
         updateCipher(name, padding.toString());
         return padding;
+    }
+
+    @JRubyMethod(name = "auth_tag=")
+    public IRubyObject set_auth_tag(IRubyObject authTag) {
+        return authTag;
+    }
+
+    @JRubyMethod
+    public IRubyObject auth_tag(final ThreadContext context) {
+        final Ruby runtime = context.runtime;
+        return RubyString.newString(runtime, new ByteList(this.authTag));
     }
 
     @JRubyMethod

--- a/src/main/java/org/jruby/ext/openssl/Cipher.java
+++ b/src/main/java/org/jruby/ext/openssl/Cipher.java
@@ -1129,7 +1129,7 @@ public class Cipher extends RubyObject {
         // trying to allow update after final like cruby-openssl. Bad idea.
         if ( "RC4".equalsIgnoreCase(cryptoBase) ) return runtime.newString("");
 
-        ByteList str;
+        final ByteList str;
         try {
             final byte[] out = cipher.doFinal();
             if ( out != null ) {
@@ -1143,7 +1143,6 @@ public class Cipher extends RubyObject {
                 if ( "GCM".equalsIgnoreCase(cryptoMode) ) {
                     int tag_size = GCM_AUTH_TAG_LEN / Byte.SIZE;
                     this.authTag = new ByteList(str.bytes(), str.length() - tag_size, tag_size).bytes();
-                    str = new ByteList(str.bytes(), 0, str.length() - tag_size);
                 }
             }
             else {


### PR DESCRIPTION
This pr is far from mergable but it gives us enough to keep going with our migration from mri to jruby.

The issue is java 8 does not support using an IvParameterSpec with GCM as can be seen in this bug. [SANTUARIO-392](https://issues.apache.org/jira/browse/SANTUARIO-392) so we added a conditional block to use the gcm spec object. Additionally, [ruby 2 cipher supports getting ahold of the auth_tag](http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html#method-i-auth_tag) but only after you call final, which we needed for our use case.