### PR TITLE
Recognize Android java.version

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/OpenSSL.java
+++ b/src/main/java/org/jruby/ext/openssl/OpenSSL.java
@@ -234,7 +234,13 @@ public final class OpenSSL {
     }
 
     private static String javaVersion(final String def) {
-        return SafePropertyAccessor.getProperty("java.version", def);
+        final String javaVersionProperty =
+                SafePropertyAccessor.getProperty("java.version", def);
+        if (javaVersionProperty == "0") { // Android
+            return "1.7.0";
+        } else {
+            return javaVersionProperty;
+        }
     }
 
     static boolean javaVersion7(final boolean atLeast) {


### PR DESCRIPTION
This change enables JOpenSSL on Android.  Android has roughly Java 1.7 API.