### PR TITLE
Make ALL cipher string match ECDHE ciphers

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/CipherStrings.java
+++ b/src/main/java/org/jruby/ext/openssl/CipherStrings.java
@@ -598,7 +598,7 @@ public class CipherStrings {
     static {
         Definitions = new HashMap<String, Def>( 48, 1 );
         // TODO review base on OpenSSL's static const SSL_CIPHER cipher_aliases[] ?!
-        Definitions.put(SSL_TXT_ALL,new Def(0,SSL_TXT_ALL, 0,SSL_ALL & ~SSL_eNULL & ~SSL_kECDH & ~SSL_kECDHE, SSL_ALL ,0,0,0,SSL_ALL,SSL_ALL));
+        Definitions.put(SSL_TXT_ALL,new Def(0,SSL_TXT_ALL, 0,SSL_ALL & ~SSL_eNULL, SSL_ALL ,0,0,0,SSL_ALL,SSL_ALL));
         Definitions.put(SSL_TXT_CMPALL,new Def(0,SSL_TXT_CMPALL,0,SSL_eNULL,0,0,0,0,SSL_ENC_MASK,0));
         Definitions.put(SSL_TXT_CMPDEF,new Def(0,SSL_TXT_CMPDEF,0,SSL_ADH, 0,0,0,0,SSL_AUTH_MASK,0));
         Definitions.put(SSL_TXT_kKRB5,new Def(0,SSL_TXT_kKRB5,0,SSL_kKRB5,0,0,0,0,SSL_MKEY_MASK,0));

--- a/src/test/ruby/ssl/test_context.rb
+++ b/src/test/ruby/ssl/test_context.rb
@@ -102,4 +102,46 @@ class TestSSLContext < TestCase
     assert_raises(TypeError) { context.ssl_version = 12 }
   end
 
+  def test_context_ciphers
+    context = OpenSSL::SSL::SSLContext.new
+    context.ciphers = "ALL"
+
+    all_ciphers = context.ciphers.map{|cipher_array| cipher_array[0]}
+
+    expected_ciphers = ["ECDHE-ECDSA-AES256-SHA",
+                        "ECDHE-RSA-AES256-SHA",
+                        "AES256-SHA",
+                        "ECDH-ECDSA-AES256-SHA",
+                        "ECDH-RSA-AES256-SHA",
+                        "DHE-RSA-AES256-SHA",
+                        "DHE-DSS-AES256-SHA",
+                        "ECDHE-ECDSA-AES128-SHA256",
+                        "ECDHE-RSA-AES128-SHA256",
+                        "ECDH-ECDSA-AES128-SHA256",
+                        "ECDH-RSA-AES128-SHA256",
+                        "ECDHE-ECDSA-AES128-SHA",
+                        "ECDHE-RSA-AES128-SHA",
+                        "AES128-SHA",
+                        "ECDH-ECDSA-AES128-SHA",
+                        "ECDH-RSA-AES128-SHA",
+                        "DHE-RSA-AES128-SHA",
+                        "DHE-DSS-AES128-SHA",
+                        "ECDHE-ECDSA-DES-CBC3-SHA",
+                        "ECDHE-RSA-DES-CBC3-SHA",
+                        "DES-CBC3-SHA",
+                        "ECDH-ECDSA-DES-CBC3-SHA",
+                        "ECDH-RSA-DES-CBC3-SHA",
+                        "EDH-RSA-DES-CBC3-SHA",
+                        "EDH-DSS-DES-CBC3-SHA",
+                        "AECDH-AES256-SHA",
+                        "ADH-AES256-SHA",
+                        "AECDH-AES128-SHA",
+                        "ADH-AES128-SHA",
+                        "AECDH-DES-CBC3-SHA",
+                        "ADH-DES-CBC3-SHA"]
+
+    expected_ciphers.each do |cipher|
+      assert all_ciphers.include?(cipher), "#{cipher} should have been included"
+    end
+  end if RUBY_VERSION > '1.9'
 end


### PR DESCRIPTION
MRI includes ECDHE ciphers under the `ALL` cipher string and this replicates that behavior. This doesn't fully solve jruby/jruby#1774 but it at least makes ECDHE ciphers available under `ALL`. There are other issues with `CipherStrings` (see: https://github.com/jruby/jruby/issues/1738#issuecomment-168152129) that need to be worked out, but this fixes my current use case.

The following ciphers are added to the `ALL` cipher string:
``` ruby
[93] pry(main)> jruby_ciphers_new - jruby_ciphers_old
=> ["ECDHE-ECDSA-AES256-SHA",
 "ECDHE-RSA-AES256-SHA",
 "ECDH-ECDSA-AES256-SHA",
 "ECDH-RSA-AES256-SHA",
 "ECDHE-ECDSA-AES128-SHA256",
 "ECDHE-RSA-AES128-SHA256",
 "ECDH-ECDSA-AES128-SHA256",
 "ECDH-RSA-AES128-SHA256",
 "ECDHE-ECDSA-AES128-SHA",
 "ECDHE-RSA-AES128-SHA",
 "ECDH-ECDSA-AES128-SHA",
 "ECDH-RSA-AES128-SHA",
 "ECDHE-ECDSA-DES-CBC3-SHA",
 "ECDHE-RSA-DES-CBC3-SHA",
 "ECDH-ECDSA-DES-CBC3-SHA",
 "ECDH-RSA-DES-CBC3-SHA",
 "AECDH-AES256-SHA",
 "AECDH-AES128-SHA",
 "AECDH-DES-CBC3-SHA"]
```

I also verified that no new ciphers were added that aren't already included by MRI

``` ruby
[94] pry(main)> jruby_ciphers_old - mri_ciphers
=> ["DES-CBC-SHA", "EDH-RSA-DES-CBC-SHA", "ADH-DES-CBC-SHA", "EXP-DES-CBC-SHA", "EXP-EDH-RSA-DES-CBC-SHA", "EXP-EDH-DSS-DES-CBC-SHA", "EXP-ADH-DES-CBC-SHA"]
[95] pry(main)> jruby_ciphers_new - mri_ciphers
=> ["DES-CBC-SHA", "EDH-RSA-DES-CBC-SHA", "ADH-DES-CBC-SHA", "EXP-DES-CBC-SHA", "EXP-EDH-RSA-DES-CBC-SHA", "EXP-EDH-DSS-DES-CBC-SHA", "EXP-ADH-DES-CBC-SHA"]
```