### PR TITLE
Don't print a warning for missing client certs

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -958,7 +958,7 @@ public class SSLSocket extends RubyObject {
             throw X509Cert.newCertificateError(runtime, e);
         }
         catch (SSLPeerUnverifiedException e) {
-            if (runtime.isVerbose() || OpenSSL.isDebug(runtime)) {
+            if (OpenSSL.isDebug(runtime)) {
                 runtime.getWarnings().warning(String.format("%s: %s", e.getClass().getName(), e.getMessage()));
             }
         }


### PR DESCRIPTION
When you run Ruby with warnings enabled and your (HTTPS) server does not verify clients you don't expect to see a warning about clients not being verified. 

For example, WEBrick's default configuration does not verify client certificates (https://github.com/jruby/jruby/blob/b610805cd55ef5d56d8e431918753fc92fad5ef5/lib/ruby/stdlib/webrick/ssl.rb#L74), but when running an HTTP server in JRuby it prints "warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated" for every request. This does not happen in MRI.

I have created an example script that shows the warnings: https://gist.github.com/iconara/09cf277e1854bed57fa132abf036e782

There doesn't seem to be any tests that cover what warnings are printed, so this PR does not include any tests. If there are tests that I can write to cover this I would be happy to write them if you can point me in the right direction.