### PR TITLE
Fix ClassCastException in X509Store.verify

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/X509StoreContext.java
+++ b/src/main/java/org/jruby/ext/openssl/X509StoreContext.java
@@ -127,9 +127,17 @@ public class X509StoreContext extends RubyObject {
         final List<X509AuxCertificate> _chain;
         if ( ! chain.isNil() ) {
             @SuppressWarnings("unchecked")
-            final List<X509Cert> certs = (List<X509Cert>) chain; // RubyArray
+            final RubyArray certs = (RubyArray) chain;
             _chain = new ArrayList<X509AuxCertificate>( certs.size() );
-            for ( X509Cert x : certs ) _chain.add( x.getAuxCert() );
+
+            for (int i = 0; i < certs.size(); i++) {
+                // NOTE: if we use the normal java syntax for iterating over this
+                // RubyArray, the `toJava` method of the X509Cert class will be
+                // implicitly called, and that will return the BC certificate object
+                // rather than the JRuby one.
+                X509Cert c = (X509Cert) certs.eltOk(i);
+                _chain.add(c.getAuxCert());
+            }
         }
         else {
             _chain = new ArrayList<X509AuxCertificate>(4);


### PR DESCRIPTION
This commit changes the logic of the `X509StoreContext.initialize`
method, to address some test failures that were showing up in
`test_x509store.rb`.  The failures would occur during calls to
the `verify` method of `X509Store`.

It seems that the failures were introduced by the addition of the
`X509Cert.toJava` method in ecc1a05f458bdc05d6d0f6fd025f8788ded0f120 .
The `toJava` method seems to be implicitly called when iterating over
a RubyArray in Java code, and the implementation of that method
now returns a BC object rather than the expected JRuby `X509Cert`
object.

This commit changes the iteration to use the `.eltOk` method to access
the underlying objects w/o the implicit call to `toJava`.