### PR TITLE
Add renegotiation cb

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -175,6 +175,7 @@ public class SSLContext extends RubyObject {
         SSLContext.addReadWriteAttribute(context, "session_id_context");
         SSLContext.addReadWriteAttribute(context, "tmp_dh_callback");
         SSLContext.addReadWriteAttribute(context, "servername_cb");
+        SSLContext.addReadWriteAttribute(context, "renegotiation_cb");
 
         SSLContext.defineAlias("ssl_timeout", "timeout");
         SSLContext.defineAlias("ssl_timeout=", "timeout=");

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -132,13 +132,11 @@ public class SSLSocket extends RubyObject {
     private ByteBuffer dummy;
 
     private boolean initialHandshake = false;
-    private boolean handshaken = false;
 
     private SSLEngineResult.HandshakeStatus handshakeStatus;
     private SSLEngineResult.Status status;
 
     int verifyResult = X509Utils.V_OK;
-
 
     @Deprecated
     public IRubyObject _initialize(final ThreadContext context,

--- a/src/test/ruby/ssl/test_ssl.rb
+++ b/src/test/ruby/ssl/test_ssl.rb
@@ -185,4 +185,17 @@ class TestSSL < TestCase
     end
   end if RUBY_VERSION > '1.9'
 
+  def test_renegotiation_cb
+    num_handshakes = 0
+    renegotiation_cb = Proc.new { |ssl| num_handshakes += 1 }
+    ctx_proc = Proc.new { |ctx| ctx.renegotiation_cb = renegotiation_cb }
+    start_server(PORT, OpenSSL::SSL::VERIFY_NONE, true, {:ctx_proc => ctx_proc}) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ssl = OpenSSL::SSL::SSLSocket.new(sock)
+      ssl.connect
+      assert_equal(1, num_handshakes)
+      ssl.close
+    end
+  end
+
 end


### PR DESCRIPTION
An attempt to resolve: https://github.com/jruby/jruby-openssl/issues/120

Let me know if you think the callback call is in the correct place. Based on comparing what CRuby does, which basically delegates to OpenSSL, I think the current location makes the most sense, but I also played around with putting it at the start of the doHandshake() method.

I had some difficulty getting my environment set up correctly, and wasn't able to run the full ruby test suite, but the java tests and the tests in the test_ssl.rb pass. I'm hoping the CI keeps me honest.
