### PR TITLE
README: Use SVG badge icons [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ NOTE: you can pick any jruby version which is on [central][4] or on [ci.jruby][5
 
 (c) 2009-2017 JRuby distributed under EPL 1.0/GPL 2.0/LGPL 2.1
 
-[0]: https://secure.travis-ci.org/jruby/jruby-openssl.png
+[0]: https://secure.travis-ci.org/jruby/jruby-openssl.svg
 [1]: http://xircles.codehaus.org/projects/jruby/lists
 [2]: https://github.com/jruby/jruby/issues
 [3]: https://github.com/jruby/jruby-openssl/tree/master/integration


### PR DESCRIPTION
This PR updates the badge icon to a more readable SVG.