### PR TITLE
If data is not provided, extract it from the PKCS7 instance.

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/PKCS7.java
+++ b/src/main/java/org/jruby/ext/openssl/PKCS7.java
@@ -190,6 +190,8 @@ public class PKCS7 extends RubyObject {
             default: pkcs7 = (PKCS7) args[0];
         }
 
+        if (data.isNil()) data = pkcs7.getData();
+
         final int flg = flags.isNil() ? 0 : RubyNumeric.fix2int(flags);
 
         String smime = "";


### PR DESCRIPTION
Fixes #132.

@kares I'm not sure if there's an MRI test that would pass now because of this change, or if we should just add our own (and not sure where that would go).