### PR TITLE
move "DEFAULT" handling right into CipherStrings

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/CipherStrings.java
+++ b/src/main/java/org/jruby/ext/openssl/CipherStrings.java
@@ -488,7 +488,22 @@ public class CipherStrings {
         final List<Def> matchedList = new LinkedList<Def>();
         Set<Def> removed = null;
 
-        for ( final String part : cipherString.split("[:, ]+") ) {
+        /*
+         * If the rule_string begins with DEFAULT, apply the default rule
+         * before using the (possibly available) additional rules.
+         * (Matching OpenSSL behaviour)
+         */
+        int offset = 0;
+        final String[] parts = cipherString.split("[:, ]+");
+        if ( parts.length >= 1 && "DEFAULT".equals(parts[0]) ) {
+            final Collection<Def> matching = matchingCiphers(SSL_DEFAULT_CIPHER_LIST, all, setSuite);
+            matchedList.addAll(matching);
+            offset = offset + 1;
+        }
+
+        for ( int i = offset; i < parts.length; i++ ) {
+            final String part = parts[i];
+
             if ( part.equals("@STRENGTH") ) {
                 Collections.sort(matchedList); continue;
             }

--- a/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -499,9 +499,6 @@ public class SSLContext extends RubyObject {
         }
         else {
             this.ciphers = ciphers.asString().toString();
-            if ( "DEFAULT".equals( this.ciphers ) ) {
-                this.ciphers = CipherStrings.SSL_DEFAULT_CIPHER_LIST;
-            }
         }
         if ( matchedCiphers(context).isEmpty() ) {
             throw newSSLError(context.runtime, "no cipher match");

--- a/src/test/ruby/ssl/test_context.rb
+++ b/src/test/ruby/ssl/test_context.rb
@@ -47,6 +47,11 @@ class TestSSLContext < TestCase
     assert ex.message =~ /\u{ff33 ff33 ff2c}/
   end
 
+  def test_default_handling # GH-2193 JRuby
+    ctx = OpenSSL::SSL::SSLContext.new
+    assert_nothing_raised { ctx.ciphers = "DEFAULT:!aNULL" }
+  end
+
   def test_verify_mode
     context = OpenSSL::SSL::SSLContext.new
     assert_nil context.verify_mode


### PR DESCRIPTION
Move "DEFAULT" special case handling further down and match OpenSSL behaviour
This fixes https://github.com/jruby/jruby/issues/2193