### PR TITLE
Account for ASN1Integers when transforming issuer serial numbers to_text in AuthorityKeyIdentifier extensions

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/X509Extension.java
+++ b/src/main/java/org/jruby/ext/openssl/X509Extension.java
@@ -458,7 +458,7 @@ public class X509Extension extends RubyObject {
                                 case 2 : // serial
                                     val.append(new byte[] { 's','e','r','i','a','l',':' });
                                     if (obj instanceof ASN1Integer) {
-                                        hexBytes( obj.getEncoded(), val);
+                                        hexBytes( ((ASN1Integer) obj).getValue().toByteArray(), val);
                                     }
                                     else {
                                         hexBytes( ((ASN1OctetString) obj ).getOctets(), val );                                        

--- a/src/main/java/org/jruby/ext/openssl/X509Extension.java
+++ b/src/main/java/org/jruby/ext/openssl/X509Extension.java
@@ -36,6 +36,7 @@ import org.bouncycastle.asn1.ASN1Boolean;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
@@ -456,7 +457,12 @@ public class X509Extension extends RubyObject {
                                     break;
                                 case 2 : // serial
                                     val.append(new byte[] { 's','e','r','i','a','l',':' });
-                                    hexBytes( ((ASN1OctetString) obj).getOctets(), val );
+                                    if (obj instanceof ASN1Integer) {
+                                        hexBytes( obj.getEncoded(), val);
+                                    }
+                                    else {
+                                        hexBytes( ((ASN1OctetString) obj ).getOctets(), val );                                        
+                                    }
                                     break;
                             }
                         }


### PR DESCRIPTION
A very tactical fix to allow for creating WEBrick servers with a self-signed cert. I noticed this when hitting this error in our code, and then tried it out in irb:

`jruby-9.1.13.0 :001 > require 'webrick'
 => true
jruby-9.1.13.0 :002 > require 'webrick/https'
 => true
jruby-9.1.13.0 :003 > cert_name = [ %w[CN localhost], ]
 => [["CN", "localhost"]]
jruby-9.1.13.0 :004 > s = WEBrick::HTTPServer.new(:Port => 0, :SSLEnable => true, :SSLCertName => cert_name)
[2017-10-18 12:24:00] INFO  WEBrick 1.3.1
[2017-10-18 12:24:00] INFO  ruby 2.3.3 (2017-09-06) [java]
Java::JavaLang::ClassCastException: org.bouncycastle.asn1.ASN1Integer cannot be cast to org.bouncycastle.asn1.ASN1OctetString
	from org.jruby.ext.openssl.X509Extension.value(X509Extension.java:475)
	from org.jruby.ext.openssl.X509CRL.extensions_to_text(X509CRL.java:398)
	from org.jruby.ext.openssl.X509Cert.to_text(X509Cert.java:381)
	from org.jruby.ext.openssl.X509Cert$INVOKER$i$0$0$to_text.call(X509Cert$INVOKER$i$0$0$to_text.gen)
	from org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:318)
	from org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:131)
	from org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:339)
	from org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
	from org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:89)
	from org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:214)
	from org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:200)
	from org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:208)
	from org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:358)
	from org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:195)
	from org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:323)
	from org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:73)
... 126 levels...
	from org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:165)
	from org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:200)
	from org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:338)
	from org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:163)
	from Users.dlampa.$_dot_rvm.rubies.jruby_minus_9_dot_1_dot_13_dot_0.bin.irb.invokeOther3:start(/Users/dlampa/.rvm/rubies/jruby-9.1.13.0/bin/irb:13)
	from Users.dlampa.$_dot_rvm.rubies.jruby_minus_9_dot_1_dot_13_dot_0.bin.irb.RUBY$script(/Users/dlampa/.rvm/rubies/jruby-9.1.13.0/bin/irb:13)
	from java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	from org.jruby.ir.Compiler$1.load(Compiler.java:95)
	from org.jruby.Ruby.runScript(Ruby.java:828)
	from org.jruby.Ruby.runNormally(Ruby.java:747)
	from org.jruby.Ruby.runNormally(Ruby.java:765)
	from org.jruby.Ruby.runFromMain(Ruby.java:578)
	from org.jruby.Main.doRunFromMain(Main.java:417)
	from org.jruby.Main.internalRun(Main.java:305)
	from org.jruby.Main.run(Main.java:232)
	from org.jruby.Main.main(Main.java:204)`

Webrick, by default, creates a self-signed cert with the authorityKeyIdentifier extension and the issuer:always modifier.

During the parsing of the authorityKeyIdentifier in `X509ExtensionFactory.parseAuthorityKeyIdentifier()` It adds a new DerTaggedObject with a ASN1Integer wrapped inside. When it unravels it during the to_text call in `X509Extension.value()` it tries to cast the ASN1Integer to an ASN1OctetString. I thought for a second that just calling ASN1Primitive.getEncoded() on the serial obj would be enough, but it caused one of the Ruby tests to fail... I have a feeling it might have to do with the other issues in the ASN1 DER parsing.

Let me know your thoughts.