### PR TITLE
loading JOpenSSL's native ext part the JRuby 9.2 (internal) way

### DIFF
--- a/lib/jopenssl/load.rb
+++ b/lib/jopenssl/load.rb
@@ -1,6 +1,5 @@
 warn 'Loading jruby-openssl gem in a non-JRuby interpreter' unless defined? JRUBY_VERSION
 
-require 'java'
 require 'jopenssl/version'
 
 warn "JRuby #{JRUBY_VERSION} is not supported by jruby-openssl #{JOpenSSL::VERSION}" if JRUBY_VERSION < '1.7.20'
@@ -26,9 +25,13 @@ unless ENV_JAVA['jruby.openssl.load.jars'].eql?('false')
   end
 end
 
-require 'jruby'
 require 'jopenssl.jar'
-org.jruby.ext.openssl.OpenSSL.load(JRuby.runtime)
+
+if JRuby::Util.respond_to?(:load_ext) # JRuby 9.2
+  JRuby::Util.load_ext('org.jruby.ext.openssl.OpenSSL')
+else; require 'jruby'
+  org.jruby.ext.openssl.OpenSSL.load(JRuby.runtime)
+end
 
 if RUBY_VERSION > '2.3'
   load 'jopenssl23/openssl.rb'


### PR DESCRIPTION
a WiP at JRuby's end ... ATM