### PR TITLE
Add ECDHE-RSA-AES128-GCM-SHA256 support

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/CipherStrings.java
+++ b/src/main/java/org/jruby/ext/openssl/CipherStrings.java
@@ -1794,6 +1794,12 @@ public class CipherStrings {
             SSL_NOT_EXP|SSL_HIGH, 128, 256, SSL_ALL_CIPHERS, SSL_ALL_STRENGTHS
         ));
 
+        SuiteToOSSL.put("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", name = "ECDHE-RSA-AES128-GCM-SHA256");
+        CipherNames.put(name, new Def(name,
+            SSL_kECDHE|SSL_RSA|SSL_AES|SSL_SHA|SSL_TLSV1,
+            SSL_NOT_EXP|SSL_HIGH, 128, 256, SSL_ALL_CIPHERS, SSL_ALL_STRENGTHS
+        ));
+
         SuiteToOSSL.put("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",   name = "ECDHE-RSA-AES256-SHA384");
 	    CipherNames.put(name, new Def(name,
             SSL_kECDHE|SSL_aRSA|SSL_AES|SSL_SHA|SSL_TLSV1,


### PR DESCRIPTION
This adds support for ECDHE-RSA-AES128-GCM-SHA256. Many more are still missing,
but I am not familiar enough with openssl to go through and configure them.