### PR TITLE
Add support for ECDHE-RSA-AES256-GCM-SHA384

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/CipherStrings.java
+++ b/src/main/java/org/jruby/ext/openssl/CipherStrings.java
@@ -1800,6 +1800,12 @@ public class CipherStrings {
             SSL_NOT_EXP|SSL_HIGH, 256, 384, SSL_ALL_CIPHERS, SSL_ALL_STRENGTHS
         ));
 
+        SuiteToOSSL.put("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",   name = "ECDHE-RSA-AES256-GCM-SHA384");
+	    CipherNames.put(name, new Def(name,
+            SSL_kECDHE|SSL_aRSA|SSL_AES|SSL_SHA|SSL_TLSV1,
+            SSL_NOT_EXP|SSL_HIGH, 256, 384, SSL_ALL_CIPHERS, SSL_ALL_STRENGTHS
+        ));
+
         SuiteToOSSL.put("TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA", name = "ECDH-ECDSA-AES128-SHA");
 	    CipherNames.put(name, new Def(name,
             SSL_kECDH|SSL_aECDSA|SSL_AES|SSL_SHA|SSL_TLSV1,


### PR DESCRIPTION
This PR is to add support for a cipher suite ECDHE-RSA-AES256-GCM-SHA384.