### PR TITLE
Try direct path for MessageDigest before invasive path

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SecurityHelper.java
+++ b/src/main/java/org/jruby/ext/openssl/SecurityHelper.java
@@ -355,11 +355,14 @@ public abstract class SecurityHelper {
      */
     public static MessageDigest getMessageDigest(final String algorithm) throws NoSuchAlgorithmException {
         try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException nsae) {
+            // try reflective logic
             final Provider provider = getSecurityProviderIfAccessible();
             if ( provider != null ) return getMessageDigest(algorithm, provider);
+
+            throw nsae; // give up
         }
-        catch (NoSuchAlgorithmException e) { }
-        return MessageDigest.getInstance(algorithm);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This logic is responsible for the remaining known "illegal access"
warning on Java 9+. I am not sure why we do not trust the default
provide to give us most algorithms, since it should be identical
to the one provied by Bouncy Castle. This change reverses the
logic and only uses the invasive provider-specific form when the
direct lookup fails.

Relates to jruby/jruby#6098.