### PR TITLE
Get all failing CI jobs report a failing CI status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - jdk: openjdk7
       env: TEST_PROFILE=test-9.1.17.0
     - jdk: oraclejdk11
-      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test" BUNDLE_INSTALL=true
     - rvm: jruby-head
   include:
     # since maven runit fails to boot with test-unit being a default gem on 9.2 :
@@ -64,19 +64,19 @@ matrix:
       rvm: jruby-head
     #
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test" BUNDLE_INSTALL=true
       rvm: jruby-1.7.26
     - jdk: openjdk7
-      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test" BUNDLE_INSTALL=true
       rvm: jruby-1.7.27
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test" BUNDLE_INSTALL=true
       rvm: jruby-9.2.8.0
     - jdk: openjdk7
-      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test" BUNDLE_INSTALL=true
       rvm: jruby-9.1.17.0
     - jdk: oraclejdk11
-      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test" BUNDLE_INSTALL=true
       rvm: jruby-9.2.9.0
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ matrix:
       rvm: jruby-1.7.27
     #
     - jdk: openjdk7
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn verify -P test-1.7.26" BUNDLE_INSTALL=true RUBY_MAVEN_VERSION=3.3.8
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn verify -P test-1.7.26" BUNDLE_INSTALL=true
+
       rvm: jruby-1.7.26
     - jdk: oraclejdk8
       env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,22 +28,22 @@ matrix:
     - jdk: openjdk7
       env: TEST_PROFILE=test-9.1.17.0
     - jdk: oraclejdk11
-      env: TEST_COMMAND="jruby -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
     - rvm: jruby-head
   include:
     # since maven runit fails to boot with test-unit being a default gem on 9.2 :
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-9.2.5.0
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-9.2.9.0
     #
     - jdk: openjdk7
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-1.7.24
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-1.7.27
     #
     - jdk: openjdk7
@@ -51,32 +51,32 @@ matrix:
 
       rvm: jruby-1.7.26
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-9.2.8.0
     - jdk: oraclejdk11
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-9.2.9.0
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-head
     - jdk: oraclejdk11
-      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -S rake test" BUNDLE_INSTALL=true
+      env: TEST_COMMAND="jruby -rbundler/setup -S rmvn test-compile && jruby -rbundler/setup -S rake test" BUNDLE_INSTALL=true
       rvm: jruby-head
     #
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
       rvm: jruby-1.7.26
     - jdk: openjdk7
-      env: TEST_COMMAND="jruby -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
       rvm: jruby-1.7.27
     - jdk: oraclejdk8
-      env: TEST_COMMAND="jruby -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
       rvm: jruby-9.2.8.0
     - jdk: openjdk7
-      env: TEST_COMMAND="jruby -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
       rvm: jruby-9.1.17.0
     - jdk: oraclejdk11
-      env: TEST_COMMAND="jruby -S rake integration:install integration:test"
+      env: TEST_COMMAND="jruby -rbundler/setup -S rake integration:install integration:test"
       rvm: jruby-9.2.9.0
 notifications:
   irc:

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ gem 'mocha', '~> 1.4', '< 2.0'
 gem 'ruby-maven', github: 'deivid-rodriguez/ruby-maven', branch: 'exit_status'
 
 # NOTE: runit-maven-plugin will use it's own :
-# gem 'test-unit', '2.5.5'
+gem 'test-unit', '2.5.5'

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,10 @@ gem "rake"
 # for less surprises with newer releases
 gem 'jar-dependencies', '~> 0.3.11', :require => nil
 
+gem 'mocha', '~> 1.4', '< 2.0'
+
 # for the rake task
 gem 'ruby-maven', github: 'deivid-rodriguez/ruby-maven', branch: 'exit_status'
+
+# NOTE: runit-maven-plugin will use it's own :
+# gem 'test-unit', '2.5.5'

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gemspec
 gem 'jar-dependencies', '~> 0.3.11', :require => nil
 
 # for the rake task
-gem 'ruby-maven', ENV['RUBY_MAVEN_VERSION'] || '~> 3.3.8'
+gem 'ruby-maven', github: 'deivid-rodriguez/ruby-maven', branch: 'exit_status'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in the gemspec
 gemspec
 
+gem "rake"
+
 # for less surprises with newer releases
 gem 'jar-dependencies', '~> 0.3.11', :require => nil
 

--- a/jruby-openssl.gemspec
+++ b/jruby-openssl.gemspec
@@ -31,13 +31,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = '>= 1.9.3'
   s.required_rubygems_version = '>= 2.4.8'
-
-  s.add_development_dependency 'jar-dependencies', '~> 0.1'
-
-  s.add_development_dependency 'mocha', '~> 1.4', '< 2.0'
-  s.add_development_dependency 'ruby-maven', '~> 3.0'
-  # NOTE: runit-maven-plugin will use it's own :
-  #s.add_development_dependency 'test-unit', '2.5.5'
 end
 
 # vim: syntax=Ruby


### PR DESCRIPTION
This PR fixes #199.

It uses the fix from https://github.com/jruby/ruby-maven/pull/1.

It also fixes some of the errors uncovered by that change.

Now a CI job should report a green status if and only if it's green.

This makes my problems with java 11 reported as #195 easily visible in CI.