### PR TITLE
Fix OpenSSL::SSL::SSLContext#min_version= failure

### DIFF
--- a/src/test/integration/ssl_test.rb
+++ b/src/test/integration/ssl_test.rb
@@ -38,4 +38,26 @@ class IntegrationSSLTest < TestCase
     puts http.get('/')
   end
 
+  def test_connect_ssl_minmax_version
+    require 'openssl'
+    require 'socket'
+
+    puts "\n"
+    puts "------------------------------------------------------------"
+    puts "-- SSL min/max version ... 'https://google.co.uk'"
+    puts "------------------------------------------------------------"
+
+    ctx = OpenSSL::SSL::SSLContext.new()
+    ctx.min_version = OpenSSL::SSL::TLS1_VERSION
+    ctx.max_version = OpenSSL::SSL::TLS1_1_VERSION
+    client = TCPSocket.new('google.co.uk', 443)
+    ssl = OpenSSL::SSL::SSLSocket.new(client, ctx)
+    ssl.sync_close = true
+    ssl.connect
+    begin
+        assert_equal 'TLSv1.1', ssl.ssl_version
+    ensure
+        ssl.sysclose
+    end
+  end
 end

--- a/src/test/ruby/ssl/test_context.rb
+++ b/src/test/ruby/ssl/test_context.rb
@@ -104,6 +104,12 @@ class TestSSLContext < TestCase
     end
     assert_raises(TypeError) { context.ssl_version = 12 }
   end
+  
+  def test_context_minmax_version
+    context = OpenSSL::SSL::SSLContext.new
+    context.min_version = OpenSSL::SSL::TLS1_VERSION
+    context.max_version = OpenSSL::SSL::TLS1_2_VERSION
+  end
 
   def test_context_ciphers
     self.class.disable_security_restrictions

--- a/src/test/ruby/ssl/test_context.rb
+++ b/src/test/ruby/ssl/test_context.rb
@@ -104,12 +104,12 @@ class TestSSLContext < TestCase
     end
     assert_raises(TypeError) { context.ssl_version = 12 }
   end
-  
+
   def test_context_minmax_version
     context = OpenSSL::SSL::SSLContext.new
     context.min_version = OpenSSL::SSL::TLS1_VERSION
     context.max_version = OpenSSL::SSL::TLS1_2_VERSION
-  end
+  end if RUBY_VERSION > '2.3'
 
   def test_context_ciphers
     self.class.disable_security_restrictions

--- a/src/test/ruby/ssl/test_helper.rb
+++ b/src/test/ruby/ssl/test_helper.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../test_helper', File.dirname(__FILE__))
+require 'openssl'
 
 module SSLTestHelper
 
@@ -7,7 +8,7 @@ module SSLTestHelper
   PORT = 20443
   ITERATIONS = ($0 == __FILE__) ? 100 : 10
 
-  def setup; require 'openssl'
+  def setup;
 
     @ca_key  = OpenSSL::PKey::RSA.new TEST_KEY_RSA2048
     @svr_key = OpenSSL::PKey::RSA.new TEST_KEY_RSA1024

--- a/src/test/ruby/ssl/test_socket.rb
+++ b/src/test/ruby/ssl/test_socket.rb
@@ -136,21 +136,6 @@ class TestSSLSocket < TestCase
     end
   end if RUBY_VERSION > '2.2'
 
-  def test_minmax_ssl_version
-    # WIP: this test should setup it's own server to prove that SSLContext.min_version and SSLContext.max_version work as expected
-    # However below line is failing  with "no cipher match" even on master
-    # When "no cipher match" is fixed, then this test need cleanup
-
-    #ssl_server = server         
-    begin
-      ssl_client = client(443, host: "google.com", min_version: OpenSSL::SSL::TLS1_VERSION, max_version: OpenSSL::SSL::TLS1_1_VERSION, ciphers: nil)
-      #ssl_client = client(server_port(ssl_server), min_version: OpenSSL::SSL::TLS1_VERSION, max_version: OpenSSL::SSL::TLS1_1_VERSION)
-      assert_equal 'TLSv1.1', ssl_client.ssl_version
-    ensure
-      ssl_client.sysclose unless ssl_client.nil?
-    end
-  end if RUBY_VERSION > '2.3'
-
   def test_inherited_socket; require 'socket'
     inheritedSSLSocket = Class.new(OpenSSL::SSL::SSLSocket)
 
@@ -165,21 +150,18 @@ class TestSSLSocket < TestCase
 
   private
 
-  def server(ssl_version: nil); require 'socket'
+  def server; require 'socket'
     host = "127.0.0.1"; port = 0
     ctx = OpenSSL::SSL::SSLContext.new()
-    ctx.ssl_version = ssl_version unless ssl_version.nil?
-    ctx.ciphers = "ADH" 
+    ctx.ciphers = "ADH"
     server = TCPServer.new(host, port)
     OpenSSL::SSL::SSLServer.new(server, ctx)
   end
 
-  def client(port, host: "127.0.0.1", min_version: nil, max_version: nil, ciphers: "ADH")
-    require 'socket'
+  def client(port); require 'socket'
+    host = "127.0.0.1"
     ctx = OpenSSL::SSL::SSLContext.new()
-    ctx.min_version = min_version unless min_version.nil?
-    ctx.max_version = max_version unless max_version.nil?
-    ctx.ciphers = ciphers unless ciphers.nil?
+    ctx.ciphers = "ADH"
     client = TCPSocket.new(host, port)
     ssl = OpenSSL::SSL::SSLSocket.new(client, ctx)
     ssl.connect

--- a/src/test/ruby/ssl/test_socket.rb
+++ b/src/test/ruby/ssl/test_socket.rb
@@ -136,6 +136,21 @@ class TestSSLSocket < TestCase
     end
   end if RUBY_VERSION > '2.2'
 
+  def test_minmax_ssl_version
+    # WIP: this test should setup it's own server to prove that SSLContext.min_version and SSLContext.max_version work as expected
+    # However below line is failing  with "no cipher match" even on master
+    # When "no cipher match" is fixed, then this test need cleanup
+
+    #ssl_server = server         
+    begin
+      ssl_client = client(443, host: "google.com", min_version: OpenSSL::SSL::TLS1_VERSION, max_version: OpenSSL::SSL::TLS1_1_VERSION, ciphers: nil)
+      #ssl_client = client(server_port(ssl_server), min_version: OpenSSL::SSL::TLS1_VERSION, max_version: OpenSSL::SSL::TLS1_1_VERSION)
+      assert_equal 'TLSv1.1', ssl_client.ssl_version
+    ensure
+      ssl_client.sysclose unless ssl_client.nil?
+    end
+  end if RUBY_VERSION > '2.3'
+
   def test_inherited_socket; require 'socket'
     inheritedSSLSocket = Class.new(OpenSSL::SSL::SSLSocket)
 
@@ -150,18 +165,21 @@ class TestSSLSocket < TestCase
 
   private
 
-  def server; require 'socket'
+  def server(ssl_version: nil); require 'socket'
     host = "127.0.0.1"; port = 0
     ctx = OpenSSL::SSL::SSLContext.new()
-    ctx.ciphers = "ADH"
+    ctx.ssl_version = ssl_version unless ssl_version.nil?
+    ctx.ciphers = "ADH" 
     server = TCPServer.new(host, port)
     OpenSSL::SSL::SSLServer.new(server, ctx)
   end
 
-  def client(port); require 'socket'
-    host = "127.0.0.1"
+  def client(port, host: "127.0.0.1", min_version: nil, max_version: nil, ciphers: "ADH")
+    require 'socket'
     ctx = OpenSSL::SSL::SSLContext.new()
-    ctx.ciphers = "ADH"
+    ctx.min_version = min_version unless min_version.nil?
+    ctx.max_version = max_version unless max_version.nil?
+    ctx.ciphers = ciphers unless ciphers.nil?
     client = TCPSocket.new(host, port)
     ssl = OpenSSL::SSL::SSLSocket.new(client, ctx)
     ssl.connect


### PR DESCRIPTION
This is attempt to fix jruby/jruby#6409.

I couldn't test it with unit tests due to other issues. However I tested it with following script 
[issue_6409.zip](https://github.com/jruby/jruby-openssl/files/5438096/issue_6409.zip)
I compared results between ruby and jruby and it seems it's working almost the same, e.g. 
* different error messages
* ruby fails when setting min_version to SSLv2
I believe these discrepancies could be ignored.

I attempted to implement unit test `test_minmax_ssl_version` however `server` method fails even on master with `no cipher match` error. So firstly master branch should be stabilized due to this and other issues before this PR can be finished.

This is still WIP, however comments are welcome.