### PR TITLE
Fix integer overflow in hash_old

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/X509Name.java
+++ b/src/main/java/org/jruby/ext/openssl/X509Name.java
@@ -633,7 +633,7 @@ public class X509Name extends RubyObject {
 
     @JRubyMethod
     public RubyFixnum hash_old() {
-        int hash;
+        long hash;
         try {
             hash = Name.hashOld( getX500Name() );
         }

--- a/src/main/java/org/jruby/ext/openssl/x509store/Name.java
+++ b/src/main/java/org/jruby/ext/openssl/x509store/Name.java
@@ -59,12 +59,12 @@ public class Name {
         this.name = name;
     }
 
-    public static int hashOld(final X500Name name) throws IOException {
+    public static long hashOld(final X500Name name) throws IOException {
         try {
             final byte[] bytes = name.getEncoded();
             MessageDigest md5 = SecurityHelper.getMessageDigest("MD5");
             final byte[] digest = md5.digest(bytes);
-            int result = 0;
+            long result = 0;
             result |= digest[3] & 0xff; result <<= 8;
             result |= digest[2] & 0xff; result <<= 8;
             result |= digest[1] & 0xff; result <<= 8;

--- a/src/test/ruby/x509/test_x509name.rb
+++ b/src/test/ruby/x509/test_x509name.rb
@@ -84,6 +84,8 @@ class TestX509Name < TestCase
   def test_hash_old
     name = OpenSSL::X509::Name.new [['CN', 'nobody'], ['DC', 'example']]
     assert_equal 1460400684, name.hash_old
+    name = OpenSSL::X509::Name.new([['CN', 'foo'], ['DC', 'bar']])
+    assert_equal 3294068023, name.hash_old
   end
 
 end


### PR DESCRIPTION
In #216 `X509Name.hash` was fixed and old implementation renamed to `hash_old`
However I discovered that old method still wasn't working correclty due to integer overflow:

> ruby -e "require 'openssl'; p OpenSSL::X509::Name.new([['CN', 'foo'], ['DC', 'bar']]).hash_old"
3294068023

> jruby -e "require 'openssl'; p OpenSSL::X509::Name.new([['CN', 'foo'], ['DC', 'bar']]).hash_old"
-1000899273

Ruby is using `unsinged int` for this calculation. In JRuby changing int to long solves the issue.