### PR TITLE
Fix SSLContext#ciphers=

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/CipherStrings.java
+++ b/src/main/java/org/jruby/ext/openssl/CipherStrings.java
@@ -560,9 +560,15 @@ public class CipherStrings {
 
     private static Collection<Def> matchingExact(final String name, final String[] all,
         final boolean setSuite) {
-        final Def pattern = Definitions.get(name);
+        Def pattern = Definitions.get(name);
         if ( pattern != null ) {
             return matchingPattern(pattern, all, true, setSuite);
+        }
+        else {
+            Def cipher = CipherNames.get(name);
+            if (cipher != null) {
+                return Collections.singleton(cipher);
+            }
         }
         return null; // Collections.emptyList();
     }

--- a/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -518,7 +518,11 @@ public class SSLContext extends RubyObject {
             StringBuilder cipherStr = new StringBuilder();
             String sep = "";
             for ( int i = 0; i < ciphs.size(); i++ ) {
-                cipherStr.append(sep).append( ciphs.eltInternal(i).toString() );
+                IRubyObject elem = ciphs.eltInternal(i);
+                if (elem instanceof RubyArray) {
+                    elem = ((RubyArray) elem).eltInternal(0);
+                }
+                cipherStr.append(sep).append( elem.toString() );
                 sep = ":";
             }
             this.ciphers = cipherStr.toString();

--- a/src/test/ruby/ssl/test_context.rb
+++ b/src/test/ruby/ssl/test_context.rb
@@ -184,4 +184,37 @@ class TestSSLContext < TestCase
     assert_equal [], diff
   end unless java7? # would need to filter out stuff such as ECDHE-RSA-AES128-GCM-SHA256
 
+  def test_set_ciphers_by_group_name
+    context = OpenSSL::SSL::SSLContext.new
+    context.ciphers = "AES"
+
+    actual = context.ciphers.map { |cipher| cipher[0]}
+    assert actual.include?("ECDHE-RSA-AES128-SHA")
+    assert actual.include?("ECDHE-ECDSA-AES128-SHA")
+    assert actual.include?("AES128-SHA")
+  end
+
+  def test_set_ciphers_by_cipher_name
+    context = OpenSSL::SSL::SSLContext.new
+    context.ciphers = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384"
+    actual = context.ciphers.map { |cipher| cipher[0]}
+    assert actual.include?("ECDHE-ECDSA-AES128-GCM-SHA256")
+    assert actual.include?("ECDHE-ECDSA-AES256-GCM-SHA384")
+  end
+
+  def test_set_ciphers_by_array_of_names
+    context = OpenSSL::SSL::SSLContext.new
+    context.ciphers = ["ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"]
+    actual = context.ciphers.map { |cipher| cipher[0]}
+    assert actual.include?("ECDHE-ECDSA-AES128-GCM-SHA256")
+    assert actual.include?("ECDHE-ECDSA-AES256-GCM-SHA384")
+  end
+
+  def test_set_ciphers_by_array_of_name_version_bits
+    context = OpenSSL::SSL::SSLContext.new
+    context.ciphers = [["ECDHE-ECDSA-AES128-GCM-SHA256", "TLSv1.2", 128, 128]]
+    actual = context.ciphers.map { |cipher| cipher[0]}
+    assert actual.include?("ECDHE-ECDSA-AES128-GCM-SHA256")
+  end
+
 end


### PR DESCRIPTION
Fixes #221 and jruby/jruby#3100

However, this functionality is not fully compatible with ruby openssl. I did some investigation and apparently jruby-openssl was implemented based on openssl 0.9.x. Ruby 2.7 is using openssl 1.1.1. 
There was a refactoring in openssl between 0.9.x and 1.1.1, e.g. following does work with ruby, but not with jruby:

```
c.ciphers='AES128'
```

but this works with both:

```
c.ciphers='AES'
```
