### PR TITLE
WIP: ALPN negotiation 

### DIFF
--- a/lib/jopenssl/version.rb
+++ b/lib/jopenssl/version.rb
@@ -1,6 +1,6 @@
 module JOpenSSL
   VERSION = '0.10.7'
-  BOUNCY_CASTLE_VERSION = '1.68'
+  BOUNCY_CASTLE_VERSION = '1.69'
 end
 
 Object.class_eval do

--- a/pom.xml
+++ b/pom.xml
@@ -60,34 +60,34 @@ DO NOT MODIFIY - GENERATED CODE
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <bc.versions>1.68</bc.versions>
+    <runit.dir>src/test/ruby/**/test_*.rb</runit.dir>
+    <polyglot.dump.readonly>false</polyglot.dump.readonly>
+    <bc.versions>1.69</bc.versions>
+    <invoker.test>${bc.versions}</invoker.test>
+    <mavengem-wagon.version>1.0.3</mavengem-wagon.version>
+    <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <mavengem.wagon.version>1.0.3</mavengem.wagon.version>
-    <jruby.switches>-W0</jruby.switches>
-    <jruby.version>9.1.17.0</jruby.version>
+    <jruby.version>9.2.9.0</jruby.version>
     <jruby.plugins.version>1.1.8</jruby.plugins.version>
     <invoker.skip>${maven.test.skip}</invoker.skip>
-    <runit.dir>src/test/ruby/**/test_*.rb</runit.dir>
-    <mavengem-wagon.version>1.0.3</mavengem-wagon.version>
-    <jruby.versions>9.1.17.0</jruby.versions>
-    <polyglot.dump.readonly>false</polyglot.dump.readonly>
-    <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
-    <invoker.test>${bc.versions}</invoker.test>
+    <jruby.switches>-W0</jruby.switches>
+    <jruby.versions>9.2.9.0</jruby.versions>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.68</version>
+      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.68</version>
+      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-jdk15on</artifactId>
-      <version>1.68</version>
+      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.jruby</groupId>

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -238,6 +238,11 @@ public class SSLSocket extends RubyObject {
     @JRubyMethod(name = "context")
     public final SSLContext context() { return this.sslContext; }
 
+    @JRubyMethod(name = "alpn_protocol")
+    public final RubyString alpn_protocol(final ThreadContext context) {
+        return RubyString.newString(context.runtime, this.engine.getApplicationProtocol());
+    }
+
     @JRubyMethod(name = "sync")
     public IRubyObject sync(final ThreadContext context) {
         final CallSite[] sites = getMetaClass().getExtraCallSites();
@@ -285,6 +290,7 @@ public class SSLSocket extends RubyObject {
             if ( ! initialHandshake ) {
                 SSLEngine engine = ossl_ssl_setup(context);
                 engine.setUseClientMode(true);
+                sslContext.setApplicationProtocols(engine);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
                 initialHandshake = true;
@@ -359,6 +365,7 @@ public class SSLSocket extends RubyObject {
                         engine.setNeedClientAuth(true);
                     }
                 }
+                sslContext.setApplicationProtocols(engine);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
                 initialHandshake = true;

--- a/src/test/ruby/ssl/test_session.rb
+++ b/src/test/ruby/ssl/test_session.rb
@@ -30,6 +30,25 @@ class TestSSLSession < TestCase
     end
   end
 
+  def test_alpn_protocol_selection_ary
+    advertised = ["h2", "http/1.1"]
+    ctx_proc = Proc.new { |ctx|
+      ctx.alpn_select_cb = -> (protocols) {
+        protocols.first
+      }
+    }
+    start_server0(PORT, OpenSSL::SSL::VERIFY_NONE, true, ctx_proc: ctx_proc) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ctx = OpenSSL::SSL::SSLContext.new("TLSv1_2")
+      ctx.alpn_protocols = advertised
+      ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+      ssl.sync_close = true
+      ssl.connect
+      assert_equal("h2", ssl.alpn_protocol)
+      ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+    end
+  end
+
   def test_exposes_session_error
     OpenSSL::SSL::Session::SessionError
   end


### PR DESCRIPTION
This MR adds support for using the ALPN extension from bouncycastle (and when using `jsse.BCSSLEngine`). It:

* updates BC to `1.69`;
* adds an alpn negotiation test from `ruby-openssl`;
* implements the necessary `SSLSocket` and `SSLContext` ALPN ruby APIs:
  * `OpenSSL::SSL::SSLSocket#alpn_protocol`
  * `OpenSSL::SSL::SSLContext#alpn_protocols (rw)`
  * `OpenSSL::SSL::SSLContext#alpn_select_cb`
* adds the `BCSSLEngine` client/server APIs.

**Pending**

* [ ] Fix `OpenSSL::SSL::SSLContext#initialize` (`OpenSSL::SSL::SSLContext.new("Unsupported")` should raise exception instead)
* [ ] Fix SSL provider selection (should jruby switch support to `jsse` only?)
* [ ] Fix cipher suite (more below)

## how to reproduce

After building the jar for tests (via `rake test_prepare`):

```bash
> JAVA_OPTS="-Djruby.openssl.ssl.provider=BC" bundle exec ruby -Itest src/test/ruby/ssl/test_session.rb --name /alpn_protocol_selection_ary/
```

## why it's not working yet

The test doesn't run yet. The error I get is:

```
org.bouncycastle.tls.TlsFatalAlert: handshake_failure(40); No selectable cipher suite
        at org.bouncycastle.tls.AbstractTlsServer.getSelectedCipherSuite(AbstractTlsServer.java:438)
        at org.bouncycastle.jsse.provider.ProvTlsServer.getSelectedCipherSuite(ProvTlsServer.java:529)
        at org.bouncycastle.tls.TlsServerProtocol.generateServerHello(TlsServerProtocol.java:570)
        at org.bouncycastle.tls.TlsServerProtocol.handleHandshakeMessage(TlsServerProtocol.java:902)
        at org.bouncycastle.tls.TlsProtocol.processHandshakeQueue(TlsProtocol.java:635)
        at org.bouncycastle.tls.TlsProtocol.processRecord(TlsProtocol.java:524)
        at org.bouncycastle.tls.RecordStream.readFullRecord(RecordStream.java:207)
        at org.bouncycastle.tls.TlsProtocol.safeReadFullRecord(TlsProtocol.java:830)
        at org.bouncycastle.tls.TlsProtocol.offerInput(TlsProtocol.java:1210)
        at org.bouncycastle.tls.TlsProtocol.offerInput(TlsProtocol.java:1178)
        at org.bouncycastle.jsse.provider.ProvSSLEngine.unwrap(ProvSSLEngine.java:464)
        at java.base/javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:634)
        at org.jruby.ext.openssl.SSLSocket.readAndUnwrap(SSLSocket.java:715)
        at org.jruby.ext.openssl.SSLSocket.doHandshake(SSLSocket.java:580)
        at org.jruby.ext.openssl.SSLSocket.acceptImpl(SSLSocket.java:374)
        at org.jruby.ext.openssl.SSLSocket.accept(SSLSocket.java:326)
```

I suspect this has to do with the advertised cipher suites in `jruby-openssl` (`OpenSSL::SSL::SSLContext.new(:"TLSv1_2").ciphers.each { |c| p c}.sort` only returns "TLSv1/SSLv3" ciphers). I looked at the implementation in `CipherStrings.java`, and a lot seems to be outdated in regards to mapping with openssl's "SSL_CIPHER", since the constants are matching v1.0.0 .

As this definitely increases the scope of what I thought was necessary to implement ALPN negotiation, would greatly welcome some pointers on how to best overcome this, as I'm not so familiar with Java SSL APIs, and the cipher selection part of openssl in general.

cc @kares @headius  

Closes #217 