### PR TITLE
[feat] support alpn negotiation in ssl context

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -53,6 +53,7 @@ import javax.net.ssl.X509TrustManager;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
+import org.jruby.RubyString;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
 import org.jruby.RubyInteger;
@@ -60,6 +61,7 @@ import org.jruby.RubyModule;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
 import org.jruby.RubySymbol;
+import org.jruby.RubyProc;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.runtime.Arity;
@@ -242,6 +244,8 @@ public class SSLContext extends RubyObject {
         SSLContext.addReadWriteAttribute(context, "tmp_dh_callback");
         SSLContext.addReadWriteAttribute(context, "servername_cb");
         SSLContext.addReadWriteAttribute(context, "renegotiation_cb");
+        SSLContext.addReadWriteAttribute(context, "alpn_protocols");
+        SSLContext.addReadWriteAttribute(context, "alpn_select_cb");
 
         SSLContext.defineAlias("ssl_timeout", "timeout");
         SSLContext.defineAlias("ssl_timeout=", "timeout=");
@@ -451,6 +455,30 @@ public class SSLContext extends RubyObject {
             // SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_cb);
         }
 
+        final String[] alpnProtocols;
+
+        value = getInstanceVariable("@alpn_protocols");
+        if ( value != null && ! value.isNil() ) {
+            IRubyObject[] rArray = ((RubyArray) value).toJavaArray();
+            String[] protos = new String[rArray.length];
+            for(int i = 0; i < protos.length; i++) {
+                protos[i] = ((RubyString) rArray[i]).asJavaString();
+            }
+
+            alpnProtocols = protos;
+        } else {
+            alpnProtocols = null;
+        }
+
+        final RubyProc alpnSelectCb;
+        value = getInstanceVariable("@alpn_select_cb");
+        if ( value != null && ! value.isNil() ) {
+            alpnSelectCb = (RubyProc) value;
+        } else {
+            alpnSelectCb = null;
+        }
+
+
         // NOTE: no API under javax.net to support session get/new/remove callbacks
         /*
         val = ossl_sslctx_get_sess_id_ctx(self);
@@ -477,7 +505,7 @@ public class SSLContext extends RubyObject {
         */
 
         try {
-            internalContext = createInternalContext(context, cert, key, store, clientCert, extraChainCert, verifyMode, timeout);
+            internalContext = createInternalContext(context, cert, key, store, clientCert, extraChainCert, verifyMode, timeout, alpnProtocols, alpnSelectCb);
         }
         catch (GeneralSecurityException e) {
             throw newSSLError(runtime, e);
@@ -505,7 +533,7 @@ public class SSLContext extends RubyObject {
     private RubyArray matchedCiphers(final ThreadContext context) {
         final Ruby runtime = context.runtime;
         try {
-            final String[] supported = getSupportedCipherSuites(protocol);
+            final String[] supported = getSupportedCipherSuites(runtime, protocol);
             final Collection<CipherStrings.Def> cipherDefs =
                     CipherStrings.matchingCiphers(this.ciphers, supported, false);
 
@@ -688,14 +716,52 @@ public class SSLContext extends RubyObject {
         }
     }
 
-    private static String[] getSupportedCipherSuites(final String protocol)
-        throws GeneralSecurityException {
-        return dummySSLEngine(protocol).getSupportedCipherSuites();
+    void setApplicationProtocols(SSLEngine engine) {
+        if ( !(engine instanceof org.bouncycastle.jsse.BCSSLEngine) ) {
+            return;
+        }
+        if ( protocolForClient ) {
+            if ( internalContext.alpnProtocols != null ) {
+                org.bouncycastle.jsse.BCSSLParameters bcParams = new org.bouncycastle.jsse.BCSSLParameters();
+                bcParams.setApplicationProtocols(internalContext.alpnProtocols);
+                bcParams.setCipherSuites(engine.getSupportedCipherSuites()); // TODO
+                ((org.bouncycastle.jsse.BCSSLEngine) engine).setParameters(bcParams);
+            }
+        }
+        if ( protocolForServer ) {
+            if ( internalContext.alpnSelectCb != null ) {
+                ((org.bouncycastle.jsse.BCSSLEngine) engine).setBCHandshakeApplicationProtocolSelector(
+                        new org.bouncycastle.jsse.BCApplicationProtocolSelector<SSLEngine>()
+                        {
+                            public String select(SSLEngine engine, List<String> protocols) {
+                                Ruby runtime = internalContext.alpnSelectCb.getRuntime();
+                                IRubyObject[] arr = new IRubyObject[protocols.size()];
+                                for(int i = 0; i < arr.length; i++) {
+                                    arr[i] = runtime.newString(protocols.get(i));
+                                }
+                                RubyArray array = RubyArray.newArray(runtime, arr);
+
+                                IRubyObject selectedProtocol = internalContext.alpnSelectCb.getBlock().call(runtime.getCurrentContext(), (IRubyObject) array);
+                                if (selectedProtocol != null) {
+                                    return ((RubyString) selectedProtocol).toString();
+                                }
+
+                                return null;
+                            }
+                        });
+            }
+        }
+
     }
 
-    private static SSLEngine dummySSLEngine(final String protocol) throws GeneralSecurityException {
+    private static String[] getSupportedCipherSuites(Ruby runtime, final String protocol)
+        throws GeneralSecurityException {
+        return dummySSLEngine(runtime, protocol).getSupportedCipherSuites();
+    }
+
+    private static SSLEngine dummySSLEngine(Ruby runtime, final String protocol) throws GeneralSecurityException {
         javax.net.ssl.SSLContext sslContext = SecurityHelper.getSSLContext(protocol);
-        sslContext.init(null, null, null);
+        sslContext.init(null, null, OpenSSL.getSecureRandom(runtime));
         return sslContext.createSSLEngine();
     }
 
@@ -899,8 +965,9 @@ public class SSLContext extends RubyObject {
     private InternalContext createInternalContext(ThreadContext context,
         final X509Cert xCert, final PKey pKey, final Store store,
         final List<X509AuxCertificate> clientCert, final List<X509AuxCertificate> extraChainCert,
-        final int verifyMode, final int timeout) throws NoSuchAlgorithmException, KeyManagementException {
-        InternalContext internalContext = new InternalContext(xCert, pKey, store, clientCert, extraChainCert, verifyMode, timeout);
+        final int verifyMode, final int timeout,
+        final String[] alpnProtocols, final RubyProc alpnSelectCb) throws NoSuchAlgorithmException, KeyManagementException {
+        InternalContext internalContext = new InternalContext(xCert, pKey, store, clientCert, extraChainCert, verifyMode, timeout, alpnProtocols, alpnSelectCb);
         internalContext.initSSLContext(context);
         return internalContext;
     }
@@ -917,7 +984,9 @@ public class SSLContext extends RubyObject {
             final List<X509AuxCertificate> clientCert,
             final List<X509AuxCertificate> extraChainCert,
             final int verifyMode,
-            final int timeout) throws NoSuchAlgorithmException {
+            final int timeout,
+            final String[] alpnProtocols,
+            final RubyProc alpnSelectCb) throws NoSuchAlgorithmException {
 
             if ( pKey != null && xCert != null ) {
                 this.privateKey = pKey.getPrivateKey();
@@ -935,6 +1004,8 @@ public class SSLContext extends RubyObject {
             this.extraChainCert = extraChainCert;
             this.verifyMode = verifyMode;
             this.timeout = timeout;
+            this.alpnProtocols = alpnProtocols;
+            this.alpnSelectCb = alpnSelectCb;
 
             // initialize SSL context :
 
@@ -981,6 +1052,8 @@ public class SSLContext extends RubyObject {
         final List<X509AuxCertificate> extraChainCert; // empty assumed == null
 
         private final int timeout;
+        private final String[] alpnProtocols;
+        private final RubyProc alpnSelectCb;
 
         private final javax.net.ssl.SSLContext sslContext;
 

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -292,7 +292,7 @@ public class SSLSocket extends RubyObject {
 
         try {
             if ( ! initialHandshake ) {
-                SSLEngine engine = ossl_ssl_setup(context, true);
+                SSLEngine engine = ossl_ssl_setup(context, false);
                 engine.setUseClientMode(true);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
@@ -352,7 +352,7 @@ public class SSLSocket extends RubyObject {
 
         try {
             if ( ! initialHandshake ) {
-                final SSLEngine engine = ossl_ssl_setup(context, false);
+                final SSLEngine engine = ossl_ssl_setup(context, true);
                 engine.setUseClientMode(false);
                 final IRubyObject verify_mode = verify_mode(context);
                 if ( verify_mode != context.nil ) {

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -242,8 +242,9 @@ public class SSLSocket extends RubyObject {
     public final SSLContext context() { return this.sslContext; }
 
     @JRubyMethod(name = "alpn_protocol")
-    public final RubyString alpn_protocol(final ThreadContext context) {
-        return RubyString.newString(context.runtime, this.engine.getApplicationProtocol());
+    public IRubyObject alpn_protocol(final ThreadContext context) {
+        final String protocol = engine.getApplicationProtocol();
+        return protocol == null ? context.nil : RubyString.newString(context.runtime, protocol);
     }
 
     @JRubyMethod(name = "sync")

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -229,6 +229,9 @@ public class SSLSocket extends RubyObject {
         dummy = ByteBuffer.allocate(0);
         this.engine = engine;
         copySessionSetupIfSet(context);
+
+        sslContext.setApplicationProtocolsOrSelector(engine);
+
         return engine;
     }
 
@@ -290,7 +293,6 @@ public class SSLSocket extends RubyObject {
             if ( ! initialHandshake ) {
                 SSLEngine engine = ossl_ssl_setup(context, true);
                 engine.setUseClientMode(true);
-                sslContext.setApplicationProtocols(engine);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
                 initialHandshake = true;
@@ -365,7 +367,6 @@ public class SSLSocket extends RubyObject {
                         engine.setNeedClientAuth(true);
                     }
                 }
-                sslContext.setApplicationProtocols(engine);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
                 initialHandshake = true;

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -238,6 +238,11 @@ public class SSLSocket extends RubyObject {
     @JRubyMethod(name = "context")
     public final SSLContext context() { return this.sslContext; }
 
+    @JRubyMethod(name = "alpn_protocol")
+    public final RubyString alpn_protocol(final ThreadContext context) {
+        return RubyString.newString(context.runtime, this.engine.getApplicationProtocol());
+    }
+
     @JRubyMethod(name = "sync")
     public IRubyObject sync(final ThreadContext context) {
         final CallSite[] sites = getMetaClass().getExtraCallSites();
@@ -285,6 +290,7 @@ public class SSLSocket extends RubyObject {
             if ( ! initialHandshake ) {
                 SSLEngine engine = ossl_ssl_setup(context, true);
                 engine.setUseClientMode(true);
+                sslContext.setApplicationProtocols(engine);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
                 initialHandshake = true;
@@ -359,6 +365,7 @@ public class SSLSocket extends RubyObject {
                         engine.setNeedClientAuth(true);
                     }
                 }
+                sslContext.setApplicationProtocols(engine);
                 engine.beginHandshake();
                 handshakeStatus = engine.getHandshakeStatus();
                 initialHandshake = true;

--- a/src/test/ruby/ssl/test_session.rb
+++ b/src/test/ruby/ssl/test_session.rb
@@ -30,6 +30,25 @@ class TestSSLSession < TestCase
     end
   end
 
+  def test_alpn_protocol_selection_ary
+    advertised = ["h2", "http/1.1"]
+    ctx_proc = Proc.new { |ctx|
+      ctx.alpn_select_cb = -> (protocols) {
+        protocols.first
+      }
+    }
+    start_server0(PORT, OpenSSL::SSL::VERIFY_NONE, true, ctx_proc: ctx_proc) do |server, port|
+      sock = TCPSocket.new("127.0.0.1", port)
+      ctx = OpenSSL::SSL::SSLContext.new("TLSv1_2")
+      ctx.alpn_protocols = advertised
+      ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+      ssl.sync_close = true
+      ssl.connect
+      assert_equal("h2", ssl.alpn_protocol)
+      ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+    end
+  end
+
   def test_exposes_session_error
     OpenSSL::SSL::Session::SessionError
   end

--- a/src/test/ruby/ssl/test_session.rb
+++ b/src/test/ruby/ssl/test_session.rb
@@ -34,6 +34,8 @@ class TestSSLSession < TestCase
     advertised = ["h2", "http/1.1"]
     ctx_proc = Proc.new { |ctx|
       ctx.alpn_select_cb = -> (protocols) {
+        assert_equal Array, protocols.class
+        assert_equal advertised, protocols
         protocols.first
       }
     }


### PR DESCRIPTION
Follow up on getting ALPN finished (from https://github.com/jruby/jruby-openssl/pull/238) : 

* adds an alpn negotiation test from `ruby-openssl`;
* implements the necessary `SSLSocket` and `SSLContext` ALPN ruby APIs:
  * `OpenSSL::SSL::SSLSocket#alpn_protocol`
  * `OpenSSL::SSL::SSLContext#alpn_protocols (rw)`
  * `OpenSSL::SSL::SSLContext#alpn_select_cb`