### PR TITLE
Add additional attr callbacks for session_cb

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -249,6 +249,10 @@ public class SSLContext extends RubyObject {
         SSLContext.addReadWriteAttribute(context, "alpn_protocols");
         SSLContext.addReadWriteAttribute(context, "alpn_select_cb");
 
+        SSLContext.addReadWriteAttribute(context, "session_get_cb");
+        SSLContext.addReadWriteAttribute(context, "session_new_cb");
+        SSLContext.addReadWriteAttribute(context, "session_remove_cb");
+
         SSLContext.defineAlias("ssl_timeout", "timeout");
         SSLContext.defineAlias("ssl_timeout=", "timeout=");
 


### PR DESCRIPTION
These are called by at least the default net-http gem, so we need
these methods to be present. I am not sure how much functionality
they need to have; in CRuby, they are just bound as attr readers/
writers.

See #249 and jruby/jruby#7088