### PR TITLE
Fix for PKCS8 EC private key support

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/PKey.java
+++ b/src/main/java/org/jruby/ext/openssl/PKey.java
@@ -129,7 +129,7 @@ public abstract class PKey extends RubyObject {
                             (DSAPrivateKey) keyPair.getPrivate(), (DSAPublicKey) keyPair.getPublic()
                     );
                 }
-                if ( "ECDSA".equals(alg) ) {
+                if ( "EC".equals(alg) ) {
                     return new PKeyEC(runtime, _PKey(runtime).getClass("EC"),
                             (PrivateKey) keyPair.getPrivate(), (PublicKey) keyPair.getPublic()
                     );
@@ -165,7 +165,7 @@ public abstract class PKey extends RubyObject {
                 if ( "DSA".equals(pubKey.getAlgorithm()) ) {
                     return new PKeyDSA(runtime, (DSAPublicKey) pubKey);
                 }
-                if ( "ECDSA".equals(pubKey.getAlgorithm()) ) {
+                if ( "EC".equals(pubKey.getAlgorithm()) ) {
                     return new PKeyEC(runtime, pubKey);
                 }
             }

--- a/src/main/java/org/jruby/ext/openssl/PKeyEC.java
+++ b/src/main/java/org/jruby/ext/openssl/PKeyEC.java
@@ -220,7 +220,7 @@ public final class PKeyEC extends PKey {
     public PrivateKey getPrivateKey() { return privateKey; }
 
     @Override
-    public String getAlgorithm() { return "ECDSA"; }
+    public String getAlgorithm() { return "EC"; }
 
     @JRubyMethod(rest = true, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(final ThreadContext context, final IRubyObject[] args, Block block) {
@@ -254,13 +254,13 @@ public final class PKeyEC extends PKey {
         Object key = null;
         final KeyFactory ecdsaFactory;
         try {
-            ecdsaFactory = SecurityHelper.getKeyFactory("ECDSA");
+            ecdsaFactory = SecurityHelper.getKeyFactory("EC");
         }
         catch (NoSuchAlgorithmException e) {
-            throw runtime.newRuntimeError("unsupported key algorithm (ECDSA)");
+            throw runtime.newRuntimeError("unsupported key algorithm (EC)");
         }
         catch (RuntimeException e) {
-            throw runtime.newRuntimeError("unsupported key algorithm (ECDSA) " + e);
+            throw runtime.newRuntimeError("unsupported key algorithm (EC) " + e);
         }
         // TODO: ugly NoClassDefFoundError catching for no BC env. How can we remove this?
         boolean noClassDef = false;
@@ -380,7 +380,7 @@ public final class PKeyEC extends PKey {
         // final ECDomainParameters params = getDomainParameters();
         try {
             ECGenParameterSpec genSpec = new ECGenParameterSpec(getCurveName());
-            KeyPairGenerator gen = SecurityHelper.getKeyPairGenerator("ECDSA"); // "BC"
+            KeyPairGenerator gen = SecurityHelper.getKeyPairGenerator("EC"); // "BC"
             gen.initialize(genSpec, new SecureRandom());
             KeyPair pair = gen.generateKeyPair();
             this.publicKey = (ECPublicKey) pair.getPublic();
@@ -517,7 +517,7 @@ public final class PKeyEC extends PKey {
         final Point point = (Point) arg;
         ECPublicKeySpec keySpec = new ECPublicKeySpec(point.asECPoint(), getParamSpec());
         try {
-            this.publicKey = (ECPublicKey) SecurityHelper.getKeyFactory("ECDSA").generatePublic(keySpec);
+            this.publicKey = (ECPublicKey) SecurityHelper.getKeyFactory("EC").generatePublic(keySpec);
             return arg;
         }
         catch (GeneralSecurityException ex) {
@@ -555,7 +555,7 @@ public final class PKeyEC extends PKey {
         }
         ECPrivateKeySpec keySpec = new ECPrivateKeySpec(s, getParamSpec());
         try {
-            this.privateKey = SecurityHelper.getKeyFactory("ECDSA").generatePrivate(keySpec);
+            this.privateKey = SecurityHelper.getKeyFactory("EC").generatePrivate(keySpec);
             return arg;
         }
         catch (GeneralSecurityException ex) {

--- a/src/main/java/org/jruby/ext/openssl/impl/PKey.java
+++ b/src/main/java/org/jruby/ext/openssl/impl/PKey.java
@@ -113,7 +113,7 @@ public class PKey {
             privSpec = new DSAPrivateKeySpec(x.getValue(), p.getValue(), q.getValue(), g.getValue());
             pubSpec = new DSAPublicKeySpec(y.getValue(), p.getValue(), q.getValue(), g.getValue());
         }
-        else if ( type.equals("ECDSA") ) {
+        else if ( type.equals("EC") ) {
             return readECPrivateKey(input);
         }
         else {
@@ -278,7 +278,7 @@ public class PKey {
 
     public static KeyPair readECPrivateKey(final byte[] input)
         throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
-        return readECPrivateKey(SecurityHelper.getKeyFactory("ECDSA"), input);
+        return readECPrivateKey(SecurityHelper.getKeyFactory("EC"), input);
     }
 
     public static KeyPair readECPrivateKey(final KeyFactory ecFactory, final byte[] input)
@@ -290,7 +290,7 @@ public class PKey {
             SubjectPublicKeyInfo  pubInfo = new SubjectPublicKeyInfo(algId, pKey.getPublicKey().getBytes());
             PKCS8EncodedKeySpec   privSpec = new PKCS8EncodedKeySpec(privInfo.getEncoded());
             X509EncodedKeySpec    pubSpec = new X509EncodedKeySpec(pubInfo.getEncoded());
-            //KeyFactory            fact = KeyFactory.getInstance("ECDSA", provider);
+            //KeyFactory            fact = KeyFactory.getInstance("EC", provider);
 
             ECPrivateKey privateKey = (ECPrivateKey) ecFactory.generatePrivate(privSpec);
             if ( algId.getParameters() instanceof ASN1ObjectIdentifier ) {
@@ -383,5 +383,3 @@ public class PKey {
         return new DLSequence(vec).getEncoded();
     }
 }
-
-


### PR DESCRIPTION
This pull request fixes loading of PKCS#8 EC private keys.

The code did not parse the unencrypted PKCS8 file correctly in case of EC private key. The proposed fix skips calling the old method that did more complicated parsing. Instead it takes a similar approach to the existing code for encrypted PKCS#8, which seems to work for both RSA and EC private keys.

The change also proposes renaming `ECDSA` algorithm name to `EC`. I'm uncertain if some of the instances should remain, but at least for the KeyManager the key type must be `EC`: when the Java TLS stack calls the KeyManager (defined by jruby-openssl) to select the key alias, it uses type `EC` not `ECDSA`. Because the code previously used `ECDSA` the TLS handshake still failed even after the loading of EC key was fixed, since no match was found for key type `EC`.

Possible TODOs to improve the change:

- [ ] There is some dead code after this change that could be removed.
- [ ] Unit testing

Fixes #266

Signed-off-by: Tero Saarni <tero.saarni@est.tech>