### PR TITLE
Improve performance of Diffie-Hellman key exchange

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/PKeyDH.java
+++ b/src/main/java/org/jruby/ext/openssl/PKeyDH.java
@@ -202,9 +202,6 @@ public class PKeyDH extends PKey {
         BigInteger x;
         SecureRandom secureRandom = new SecureRandom();
         // adapting algorithm from org.bouncycastle.crypto.generators.DHKeyGeneratorHelper,
-        // which seems a little stronger (?) than OpenSSL's (OSSL just generates a random,
-        // while BC generates a random potential prime [for limit > 0], though it's not
-        // subject to Miller-Rabin [certainty = 0], but is subject to other constraints)
         // see also [ossl]/crypto/dh/dh_key.c #generate_key
         if (limit == 0) {
             final BigInteger pSub2 = p.subtract(TWO);
@@ -213,8 +210,7 @@ public class PKeyDH extends PKey {
             } while (x.equals(BigInteger.ZERO));
         } else {
             do {
-                // generate potential prime, though with 0 certainty (no Miller-Rabin tests)
-                x = new BigInteger(limit, 0, secureRandom);
+                x = new BigInteger(limit, secureRandom);
             } while (x.equals(BigInteger.ZERO));
         }
         return x;


### PR DESCRIPTION
Resolve the following issues:

1. [SSH connection stucked with NET::SSH_7.0.1 and OpenSSH_8.0 with FIPS enabled](https://github.com/jruby/jruby/issues/7353)
2. [Diffie-Hellman implementation causes key exchange to hang and consume CPU](https://github.com/jruby/jruby-openssl/issues/191)

Improve performance of Diffie-Hellman key exchange by generating a cryptographically strong random number instead of a probable prime. [RFC 4419](https://www.ietf.org/rfc/rfc4419.txt) does not require or suggest `x` (private key) be prime.

##### Background
* `net-ssh`, built on top of `openssl`, implements the `diffie-hellman-group-exchange-sha256` key exchange and supports prime modulus in the range 1024 - 8192.
* Generating probable primes using Java's `BigInteger` class is highly variable and really slows down for primes with bit lengths > 2048.
* When a SSH server sends a prime modulus with a 8192 bit length, the `jruby-openssl` algorithm generates a `BigInteger` probable prime for `x` with the same bit length. Usually the server hangs up before the prime is available.
* [RFC 4419](https://www.ietf.org/rfc/rfc4419.txt) and [RFC 4253](https://www.ietf.org/rfc/rfc4253.txt) both indicate the private key is a random number, not a prime.
* Other implementations of the Diffie-Hellman key exchange algorithm don't generate primes for the private key. Here are a few examples:
  * [Bouncy Castle](https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/crypto/generators/DHKeyGeneratorHelper.java)
  * [Go](https://cs.opensource.google/go/x/crypto/+/master:ssh/kex.go;l=106)
  * [Java](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/com/sun/crypto/provider/DHKeyPairGenerator.java#L193)
  * [OpenSSL C](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/dh/dh_key.c#L153)

##### Benchmarks
![newplot](https://user-images.githubusercontent.com/16247924/211593769-fd7bc753-010c-49e6-8813-90ca6c76563c.png)

☝️ Box plots (log scale) showing how long it takes to generate a probable prime of various bit lengths using the following constructor:

```java
// https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/math/BigInteger.html#%3Cinit%3E(int,int,java.util.Random)
BigInteger(int bitLength, int certainty, Random rnd);
```

Hoping to get this in the next release of JRuby.

@kares @headius 
