### PR TITLE
[deps] upgrade BC to latest 1.75

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 ## 0.14.2
 
-* [deps] upgrade BC to latest 1.74
+* [deps] upgrade BC to latest 1.75
 
 ## 0.14.1
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the JRuby [mailing list][1] or the [bug tracker][2].
 |      ~>0.11.x | 9.0.x-9.3.x  |  Java 7-11 |    1.62-1.68 |
 |      ~>0.12.x | 9.1.x-9.3.x  |  Java 8-15 |    1.65-1.68 |
 |      ~>0.13.x | 9.1.x-9.4.x  |  Java 8-17 |    1.68-1.69 |
-|      ~>0.14.x | 9.1.x-9.4.x  |  Java 8-17 |    1.71-1.74 |
+|      ~>0.14.x | 9.1.x-9.4.x  |  Java 8-17 |    1.71-1.75 |
 
 NOTE: backwards JRuby compatibility was not handled for versions <= **0.9.6** 
 

--- a/lib/jopenssl/version.rb
+++ b/lib/jopenssl/version.rb
@@ -1,6 +1,6 @@
 module JOpenSSL
   VERSION = '0.14.2.dev'
-  BOUNCY_CASTLE_VERSION = '1.74'
+  BOUNCY_CASTLE_VERSION = '1.75'
 end
 
 Object.class_eval do

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ DO NOT MODIFY - GENERATED CODE
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <bc.versions>1.74</bc.versions>
+    <bc.versions>1.75</bc.versions>
     <invoker.skip>${maven.test.skip}</invoker.skip>
     <invoker.test>${bc.versions}</invoker.test>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -77,22 +77,22 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.74</version>
+      <version>1.75</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.74</version>
+      <version>1.75</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-jdk18on</artifactId>
-      <version>1.74</version>
+      <version>1.75</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>1.74</version>
+      <version>1.75</version>
     </dependency>
     <dependency>
       <groupId>org.jruby</groupId>


### PR DESCRIPTION
There was a relatively unusual quick follow-up bugfix to `1.74` (subsequent to #278), likely due to accidental breakage in Java 5-7 compatible versions irrelevant to jruby, but no harm keeping up-to-date.

https://www.bouncycastle.org/releasenotes.html#r1rv75

