### PR TITLE
[fix] try value#to_der when creating ASN.1 sequence

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -1935,6 +1935,10 @@ public class ASN1 {
                     if ( addEntry(context, vec, val.entry(i)) ) break;
                 }
             }
+            else if (respondsTo("to_der")) {
+                IRubyObject entry = value.callMethod(context, "to_der");
+                addEntry(context, vec, entry);
+            }
             else {
                 final int size = RubyInteger.num2int(value.callMethod(context, "size"));
                 for ( int i = 0; i < size; i++ ) {

--- a/src/test/ruby/test_asn1.rb
+++ b/src/test/ruby/test_asn1.rb
@@ -21,6 +21,18 @@ class TestASN1 < TestCase
     assert_equal i, OpenSSL::ASN1.decode(ai.to_der).value
   end
 
+  def test_encode_nested_sequence_to_der
+    data_sequence = ::OpenSSL::ASN1::Sequence([::OpenSSL::ASN1::Integer(0)])
+    asn1 = ::OpenSSL::ASN1::Sequence(data_sequence)
+    assert_equal "0\x03\x02\x01\x00", asn1.to_der
+  end
+
+  def test_encode_nested_set_to_der
+    data_set = ::OpenSSL::ASN1::Set([::OpenSSL::ASN1::Integer(0)])
+    asn1 = ::OpenSSL::ASN1::Set(data_set)
+    assert_equal "1\x03\x02\x01\x00", asn1.to_der
+  end
+
   def test_encode_nil
     #Primitives raise TypeError, Constructives NoMethodError
 


### PR DESCRIPTION
Could fix https://github.com/jruby/jruby-openssl/issues/282

I noticed that there is an expectation that anything inside of an ASN1 object is either a RubyArray or a object that responds to `[]` this checks to see if the sub object responds to `#to_der` and calls that method. I was unable to get the test suite to run locally on my M1 pro, and would like to be able to test on here using the suites.

Works and doesn't work before this PR.

**Works**
```ruby
data_sequence = ::OpenSSL::ASN1::Sequence([::OpenSSL::ASN1::Integer(0)])
asn1 = ::OpenSSL::ASN1::Sequence([data_sequence])
asn1.to_der
```

**Doesn't work but should**
```ruby
data_sequence = ::OpenSSL::ASN1::Sequence([::OpenSSL::ASN1::Integer(0)])
asn1 = ::OpenSSL::ASN1::Sequence(data_sequence)
asn1.to_der
```
