### PR TITLE
[fix] add Cipher#auth_data(arg) override (Rails 7.x compat)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name: JOSSL Tests
+name: rake test
 
 on: [push, pull_request]
 
@@ -13,15 +13,19 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 11, 15, 17 ]
-        ruby-version: [ jruby-9.3.3.0 ]
+        java-version: [ 8, 11, 17, 21 ]
+        ruby-version: [ jruby-9.4.5.0 ]
         include:
           - java-version: 8
             ruby-version: jruby-9.2.19.0
-          - java-version: 11
-            ruby-version: jruby-9.2.20.1
           - java-version: 17
             ruby-version: jruby-9.2.20.1
+          - java-version: 8
+            ruby-version: jruby-9.3.3.0
+          - java-version: 11
+            ruby-version: jruby-9.3.13.0
+          - java-version: 15
+            ruby-version: jruby-9.3.13.0
           - java-version: 8
             ruby-version: jruby-9.1.17.0
       fail-fast: false

--- a/.github/workflows/ci-test_provider.yml
+++ b/.github/workflows/ci-test_provider.yml
@@ -1,4 +1,4 @@
-name: JOSSL Tests (Provider)
+name: rake test (with provider)
 
 on: [push, pull_request]
 
@@ -14,7 +14,10 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11, 17 ]
-        ruby-version: [ jruby-9.3.3.0 ]
+        ruby-version: [ jruby-9.3.13.0 ]
+        include:
+          - java-version: 21
+            ruby-version: jruby-9.4.5.0
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci-test_provider.yml
+++ b/.github/workflows/ci-test_provider.yml
@@ -9,7 +9,7 @@ env:
 jobs:
 
   maven-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ gem 'jar-dependencies', '>= 0.3.11', require: false
 gem 'mocha', '~> 1.4', '< 2.0'
 
 # NOTE: runit-maven-plugin will use it's own :
-gem 'test-unit', '2.5.5'
+gem 'test-unit'


### PR DESCRIPTION
incomplete (see NOTEs in tests) but expected to be sufficient for Rails 7's `use_authenticated_cookie_encryption` 