### PR TITLE
Fixes for gem push issues on MacOS M1

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.torquebox.mojo</groupId>
+    <groupId>org.jruby.maven</groupId>
     <artifactId>mavengem-wagon</artifactId>
-    <version>1.0.3</version>
+    <version>2.0.2</version>
   </extension>
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.4.8</version>
+    <version>0.7.0</version>
   </extension>
 </extensions>

--- a/Mavenfile
+++ b/Mavenfile
@@ -107,15 +107,15 @@ supported_bc_versions = %w{ 1.60 1.61 1.62 1.63 1.64 1.65 1.66 1.67 1.68 }
 default_bc_version = File.read File.expand_path('lib/jopenssl/version.rb', File.dirname(__FILE__))
 default_bc_version = default_bc_version[/BOUNCY_CASTLE_VERSION\s?=\s?'(.*?)'/, 1]
 
-properties( 'jruby.plugins.version' => '2.0.1', # 2.0.1
+properties( 'jruby.plugins.version' => '3.0.2',
             'jruby.switches' => '-W0', # https://github.com/torquebox/jruby-maven-plugins/issues/94
             'bc.versions' => default_bc_version,
             'invoker.test' => '${bc.versions}',
             # allow to skip all tests with -Dmaven.test.skip
             'invoker.skip' => '${maven.test.skip}',
             'runit.dir' => 'src/test/ruby/**/test_*.rb',
-            'mavengem.wagon.version' => '1.0.3', # for jruby plugin
-            'mavengem-wagon.version' => '1.0.3', # for polyglot-ruby
+            'mavengem.wagon.version' => '2.0.2', # for jruby plugin
+            'mavengem-wagon.version' => '2.0.2', # for polyglot-ruby
             # use this version of jruby for the jruby-maven-plugins
             'jruby.versions' => MVN_JRUBY_VERSION, 'jruby.version' => MVN_JRUBY_VERSION,
             # dump pom.xml when running 'rmvn'

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@ DO NOT MODIFY - GENERATED CODE
     <bc.versions>1.78</bc.versions>
     <invoker.skip>${maven.test.skip}</invoker.skip>
     <invoker.test>${bc.versions}</invoker.test>
-    <jruby.plugins.version>2.0.1</jruby.plugins.version>
+    <jruby.plugins.version>3.0.2</jruby.plugins.version>
     <jruby.switches>-W0</jruby.switches>
     <jruby.version>9.2.19.0</jruby.version>
     <jruby.versions>9.2.19.0</jruby.versions>
-    <mavengem-wagon.version>1.0.3</mavengem-wagon.version>
-    <mavengem.wagon.version>1.0.3</mavengem.wagon.version>
+    <mavengem-wagon.version>2.0.2</mavengem-wagon.version>
+    <mavengem.wagon.version>2.0.2</mavengem.wagon.version>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>false</polyglot.dump.readonly>
     <runit.dir>src/test/ruby/**/test_*.rb</runit.dir>
@@ -122,12 +122,12 @@ DO NOT MODIFY - GENERATED CODE
   <build>
     <extensions>
       <extension>
-        <groupId>org.torquebox.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
         <version>${mavengem.wagon.version}</version>
       </extension>
       <extension>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-with-jar-extension</artifactId>
         <version>${jruby.plugins.version}</version>
       </extension>
@@ -181,7 +181,7 @@ DO NOT MODIFY - GENERATED CODE
         </executions>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <executions>
@@ -351,7 +351,7 @@ DO NOT MODIFY - GENERATED CODE
         </executions>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <executions>

--- a/src/main/java/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/main/java/org/jruby/ext/openssl/SSLSocket.java
@@ -952,7 +952,7 @@ public class SSLSocket extends RubyObject {
         }
         catch (IOException ex) {
             debugStackTrace(runtime, "SSLSocket.syswriteImpl", ex);
-            throw Utils.newError(runtime, runtime.getIOError(), ex);
+            throw runtime.newIOErrorFromException(ex);
         }
     }
 


### PR DESCRIPTION
Various fixes to get jruby-openssl building and gems pushing correctly from MacOS M1.

Primarily fixing #242.