### PR TITLE
Making parse_config accepts a String like Ruby MRI

### DIFF
--- a/lib/openssl/config.rb
+++ b/lib/openssl/config.rb
@@ -52,7 +52,11 @@ module OpenSSL
       # Raises a ConfigError on invalid configuration data.
       def parse_config(io)
         begin
-          parse_config_lines(io)
+          if(io.instance_of?(String))
+            parse(io)
+          else
+            parse_config_lines(io)
+          end
         rescue => error
           raise ConfigError, "error in line #{io.lineno}: " + error.message
         end


### PR DESCRIPTION
With Ruby MRI, we can do:


`OpenSSL::Config.parse_config("") # also accepts a String` 

but not with JRuby:

```
NoMethodError: undefined method `lineno' for "":String
   Did you mean?  lines
```