### PR TITLE
Consider SHORTNAME and shortname equal as hostname

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -314,7 +314,7 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       san_parts = san.downcase.split(".")
 
       # TODO: this behavior should probably be more strict
-      return san == hostname if san_parts.size < 2
+      return san.downcase == hostname.downcase if san_parts.size < 2
 
       # Matching is case-insensitive.
       host_parts = hostname.downcase.split(".")


### PR DESCRIPTION
There seems to be no reason to consider a local hostname as case sensitive when other hostnames are compared case insensitive.

If the behavior needs to be more strict it would be good to document in what way it is more strict than qualified domain names.