### PR TITLE
[test] remove a special test case

### DIFF
--- a/src/test/ruby/test_cipher.rb
+++ b/src/test/ruby/test_cipher.rb
@@ -470,23 +470,19 @@ class TestCipher < TestCase
 
   def test_encrypt_aes_256_cbc_modifies_buffer
     cipher = OpenSSL::Cipher.new("AES-256-CBC")
-    cipher.key = "a" * 32
     cipher.encrypt
+    cipher.key = "a" * 32
     buffer = ''
     actual = cipher.update('bar' * 10, buffer)
-    if jruby?
-      expected = "\xE6\xD3Y\fc\xEE\xBA\xB2*\x0Fr\xD1\xC2b\x03\xD0"
-    else
-      expected = "8\xA7\xBE\xB1\xAE\x88j\xCB\xA3\xE9j\x00\xD2W_\x91"
-    end
+    expected = "\xE6\xD3Y\fc\xEE\xBA\xB2*\x0Fr\xD1\xC2b\x03\xD0"
     assert_equal actual, expected
     assert_equal buffer, expected
   end
 
   def test_encrypt_aes_256_cbc_invalid_buffer
     cipher = OpenSSL::Cipher.new("AES-256-CBC")
-    cipher.key = "a" * 32
     cipher.encrypt
+    cipher.key = "a" * 32
     buffer = Object.new
     assert_raise(TypeError) { cipher.update('bar' * 10, buffer) }
   end


### PR DESCRIPTION
fixes https://github.com/jruby/jruby-openssl/pull/170/files#r204210698

CRuby now raises
_`update': key not set (OpenSSL::Cipher::CipherError)_

because the order of cipher.key= and cipher.encrypt is wrong. After fixing the test, CRuby and JRuby's outputs are the same