### PR TITLE
Fix `OpenSSL::X509::CRL#to_pem` when building CRL from scratch

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/X509CRL.java
+++ b/src/main/java/org/jruby/ext/openssl/X509CRL.java
@@ -304,7 +304,7 @@ public class X509CRL extends RubyObject {
     public IRubyObject to_pem(final ThreadContext context) {
         StringWriter writer = new StringWriter();
         try {
-            PEMInputOutput.writeX509CRL(writer, crl);
+            PEMInputOutput.writeX509CRL(writer, getCRL());
             return RubyString.newString(context.runtime, writer.getBuffer());
         }
         catch (IOException e) {


### PR DESCRIPTION
When building an CRL from scratch, the `crl` member variable has no value, and when calling `to_pem` on the object, the following value is returned instead of the actual CRL:

```
-----BEGIN X509 CRL-----
MAA=
-----END X509 CRL-----
```

The function `getCRL()` return the `crl` member variable if it is non-null, and generate the CRL and store it in this variable otherwise. It seems adequate to use this getter function rather than accessing the member variable directly.

Fixes #163
