### PR TITLE
Improving completeness of ASN1 encoding/decoding

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -703,6 +703,10 @@ public class ASN1 {
         Constructive.addReadWriteAttribute(context, "tagging");
         Constructive.defineAnnotatedMethods(Constructive.class);
 
+        final ObjectAllocator eocAllocator = EndOfContent.ALLOCATOR;
+        RubyClass EndOfContent = ASN1.defineClassUnder("EndOfContent", _ASN1Data, eocAllocator);
+        EndOfContent.defineAnnotatedMethods(EndOfContent.class);
+
         ASN1.defineClassUnder("Boolean", Primitive, primitiveAllocator); // OpenSSL::ASN1::Boolean <=> value is a Boolean
         ASN1.defineClassUnder("Integer", Primitive, primitiveAllocator); // OpenSSL::ASN1::Integer <=> value is a Number
         ASN1.defineClassUnder("Null", Primitive, primitiveAllocator); // OpenSSL::ASN1::Null <=> value is always nil
@@ -726,9 +730,6 @@ public class ASN1 {
 
         ASN1.defineClassUnder("UTCTime", Primitive, primitiveAllocator); // OpenSSL::ASN1::UTCTime <=> value is a Time
         ASN1.defineClassUnder("GeneralizedTime", Primitive, primitiveAllocator); // OpenSSL::ASN1::GeneralizedTime <=> value is a Time
-
-        ASN1.defineClassUnder("EndOfContent", _ASN1Data, asn1DataAllocator). // OpenSSL::ASN1::EndOfContent <=> value is always nil
-                defineAnnotatedMethods(EndOfContent.class);
 
         ASN1.defineClassUnder("ObjectId", Primitive, primitiveAllocator).
                 defineAnnotatedMethods(ObjectId.class);

--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -1701,12 +1701,20 @@ public class ASN1 {
 
                 if ( tag.isNil() ) throw newASN1Error(runtime, "must specify tag number");
 
-                if ( tagging.isNil() ) tagging = runtime.newSymbol("EXPLICIT");
-                if ( ! (tagging instanceof RubySymbol) ) {
-                    throw newASN1Error(runtime, "invalid tag default");
+                if ( tagging.isNil()) {
+                    if (tag_class.isNil()) {
+                        tag_class = runtime.newSymbol("UNIVERSAL");
+                    }
+                } else {
+                    if (!(tagging instanceof RubySymbol)) {
+                        throw newASN1Error(runtime, "invalid tagging method");
+                    }
+
+                    if (tag_class.isNil()) {
+                        tag_class = runtime.newSymbol("CONTEXT_SPECIFIC");
+                    }
                 }
 
-                if ( tag_class.isNil() ) tag_class = runtime.newSymbol("CONTEXT_SPECIFIC");
                 if ( ! (tag_class instanceof RubySymbol) ) {
                     throw newASN1Error(runtime, "invalid tag class");
                 }

--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -1474,6 +1474,13 @@ public class ASN1 {
                     }
                     valueBytes = valueOut.toByteArray();
                 } else {
+                    if (isIndefiniteLength) {
+                        throw newASN1Error(
+                            context.runtime,
+                            "indefinite length form cannot be used with primitive encoding"
+                        );
+                    }
+
                     final IRubyObject string = value.checkStringType();
                     if (string instanceof RubyString) {
                         valueBytes = ((RubyString) string).getBytes();

--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -1611,11 +1611,20 @@ public class ASN1 {
 
     }
 
-    public static class EndOfContent {
+    public static class EndOfContent extends ASN1Data {
 
-        private EndOfContent() {}
+        static ObjectAllocator ALLOCATOR = new ObjectAllocator() {
+            public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+                return new EndOfContent(runtime, klass);
+            }
+        };
 
-        @JRubyMethod(visibility = Visibility.PRIVATE)
+        public EndOfContent(Ruby runtime, RubyClass type) {
+            super(runtime,type);
+        }
+
+
+        @JRubyMethod(required = 0, optional = 0, visibility = Visibility.PRIVATE)
         public static IRubyObject initialize(final ThreadContext context, final IRubyObject self) {
             final Ruby runtime = context.runtime;
             self.getInstanceVariables().setInstanceVariable("@tag", runtime.newFixnum(0));
@@ -1629,6 +1638,12 @@ public class ASN1 {
             return klass.newInstance(context, Block.NULL_BLOCK);
         }
 
+        @Override
+        boolean isImplicitTagging() {
+            IRubyObject tagging = tagging();
+            if ( tagging.isNil() ) return true;
+            return "IMPLICIT".equals( tagging.toString() );
+        }
     }
 
     public static class Primitive extends ASN1Data {

--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -1204,8 +1204,10 @@ public class ASN1 {
         }
         final int length = asn1[ ++offset ] & 0xFF;
         final boolean isIndefiniteLength = length == 0x80;
+        IRubyObject decoded;
 
-        IRubyObject decoded = decodeObject(context, ASN1, readObject(in));
+        decoded = decodeObject(context, ASN1, readObject(in));
+
         final boolean isUniversal = ((ASN1Data) decoded).isUniversal(context);
 
         if (isIndefiniteLength) {

--- a/src/main/java/org/jruby/ext/openssl/ASN1.java
+++ b/src/main/java/org/jruby/ext/openssl/ASN1.java
@@ -1339,8 +1339,8 @@ public class ASN1 {
             }
         }
 
-        boolean isEOC() {
-            return "EndOfContent".equals( getClassBaseName() );
+        boolean isEOC(final ThreadContext context) {
+            return getTag(context) == 0 && isUniversal((context));
         }
 
         boolean isUniversal(final ThreadContext context) {
@@ -1420,7 +1420,7 @@ public class ASN1 {
             } else if (value instanceof ASN1Data) {
                 return new DERTaggedObject(isExplicitTagging(), tagClass, tag, ((ASN1Data) value).toASN1(context));
             } else if (value instanceof RubyObject) {
-                if (isEOC()) {
+                if (isEOC(context)) {
                     return null;
                 }
                 final IRubyObject string = value.checkStringType();
@@ -1449,7 +1449,7 @@ public class ASN1 {
         }
 
         byte[] toDER(final ThreadContext context) throws IOException {
-            if ( isEOC() ) return new byte[] { 0x00, 0x00 };
+            if (isEOC(context)) return new byte[] { 0x00, 0x00 };
 
             final boolean isIndefiniteLength = getInstanceVariable("@indefinite_length").isTrue();
 
@@ -1771,7 +1771,7 @@ public class ASN1 {
         }
 
         @Override
-        boolean isEOC() {
+        boolean isEOC(final ThreadContext context) {
             return false;
         }
 
@@ -2139,7 +2139,7 @@ public class ASN1 {
                 }
                 else if ( entry instanceof ASN1Data ) {
                     final ASN1Data data = ( (ASN1Data) entry );
-                    if ( data.isEOC() ) return true;
+                    if ( data.isEOC(context) ) return true;
                     vec.add( data.toASN1(context) );
                 }
                 else {

--- a/src/test/ruby/test_asn1.rb
+++ b/src/test/ruby/test_asn1.rb
@@ -1295,7 +1295,7 @@ dPMQD5JX6g5HKnHFg2mZtoXQrWmJSn7p8GJK8yNTopEErA==
     assert_equal 'o=Telstra', asn1_data.value[1].value
     assert_equal OpenSSL::ASN1::ASN1Data, asn1_data.value[2].class
     assert_equal :CONTEXT_SPECIFIC,  asn1_data.value[2].tag_class
-#    assert_equal 'ess', asn1_data.value[2].value
+    assert_equal 'ess', asn1_data.value[2].value
 
 #    assert_equal raw, asn1.to_der
   end

--- a/src/test/ruby/test_asn1.rb
+++ b/src/test/ruby/test_asn1.rb
@@ -509,66 +509,37 @@ class TestASN1 < TestCase
   end
 
   def test_basic_asn1data
-    # TODO: Import Issue
-    # Java::JavaLang::ClassCastException:
-    # class org.jruby.RubyString cannot be cast to class org.jruby.ext.openssl.ASN1$ASN1Data
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.toASN1TaggedObject(ASN1.java:1408)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.toASN1(ASN1.java:1383)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.toDER(ASN1.java:1424)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.to_der(ASN1.java:1414)
-    #encode_test B(%w{ 00 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 0, :UNIVERSAL)
-    #encode_test B(%w{ 01 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :UNIVERSAL)
-    #encode_decode_test B(%w{ 41 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :APPLICATION)
-    #encode_decode_test B(%w{ 81 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :CONTEXT_SPECIFIC)
-    #encode_decode_test B(%w{ C1 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :PRIVATE)
-    # TODO: Import Issue
-    # OpenSSL::ASN1::ASN1Error: tag number for :UNIVERSAL too large
-    #  org/jruby/RubyClass.java:942:in `new'
-    #encode_decode_test B(%w{ 1F 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 32, :UNIVERSAL)
-    #encode_decode_test B(%w{ 1F C0 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 8224, :UNIVERSAL)
-    # TODO: Import Issue (same as start of this test)
-    # Java::JavaLang::ClassCastException:
-    # class org.jruby.RubyString cannot be cast to class org.jruby.ext.openssl.ASN1$ASN1Data
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.toASN1TaggedObject(ASN1.java:1408)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.toASN1(ASN1.java:1383)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.toDER(ASN1.java:1424)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.to_der(ASN1.java:1414)
-    #encode_decode_test B(%w{ 41 02 AB CD }), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 1, :APPLICATION)
-    #encode_decode_test B(%w{ 41 81 80 } + %w{ AB CD } * 64), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD } * 64), 1, :APPLICATION)
-    #encode_decode_test B(%w{ 41 82 01 00 } + %w{ AB CD } * 128), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD } * 128), 1, :APPLICATION)
-    #encode_decode_test B(%w{ 61 00 }), OpenSSL::ASN1::ASN1Data.new([], 1, :APPLICATION)
-    #obj = OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 2, :PRIVATE)], 1, :APPLICATION)
-    #obj.indefinite_length = true
-    #encode_decode_test B(%w{ 61 80 C2 02 AB CD 00 00 }), obj
-    #obj = OpenSSL::ASN1::ASN1Data.new([
-    #  OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 2, :PRIVATE),
-    #  OpenSSL::ASN1::EndOfContent.new
-    #], 1, :APPLICATION)
-    #obj.indefinite_length = true
-    #encode_test B(%w{ 61 80 C2 02 AB CD 00 00 }), obj
-    #obj = OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 1, :UNIVERSAL)
-    #obj.indefinite_length = true
-    # TODO: Import Issue
-    # <OpenSSL::ASN1::ASN1Error> expected but was <#<Java::JavaLang::ClassCastException: class org.jruby.RubyString cannot be cast to class org.jruby.ext.openssl.ASN1$ASN1Data
-    #assert_raise(OpenSSL::ASN1::ASN1Error) { obj.to_der }
+    encode_test B(%w{ 00 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 0, :UNIVERSAL)
+    encode_test B(%w{ 01 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :UNIVERSAL)
+    encode_decode_test B(%w{ 41 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :APPLICATION)
+    encode_decode_test B(%w{ 81 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :CONTEXT_SPECIFIC)
+    encode_decode_test B(%w{ C1 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :PRIVATE)
+    # encode_decode_test B(%w{ 1F 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 32, :UNIVERSAL)
+    encode_decode_test B(%w{ 9F C0 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 8224, :CONTEXT_SPECIFIC)
+    encode_decode_test B(%w{ 41 02 AB CD }), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 1, :APPLICATION)
+    encode_decode_test B(%w{ 41 81 80 } + %w{ AB CD } * 64), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD } * 64), 1, :APPLICATION)
+    encode_decode_test B(%w{ 41 82 01 00 } + %w{ AB CD } * 128), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD } * 128), 1, :APPLICATION)
+    encode_decode_test B(%w{ 61 00 }), OpenSSL::ASN1::ASN1Data.new([], 1, :APPLICATION)
+    obj = OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 2, :PRIVATE)], 1, :APPLICATION)
+    obj.indefinite_length = true
+    encode_decode_test B(%w{ 61 80 C2 02 AB CD 00 00 }), obj
+    obj = OpenSSL::ASN1::ASN1Data.new([
+      OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 2, :PRIVATE),
+      OpenSSL::ASN1::EndOfContent.new
+    ], 1, :APPLICATION)
+    obj.indefinite_length = true
+    encode_test B(%w{ 61 80 C2 02 AB CD 00 00 }), obj
+    obj = OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 1, :UNIVERSAL)
+    obj.indefinite_length = true
+    assert_raise(OpenSSL::ASN1::ASN1Error) { obj.to_der }
   end
 
   def test_basic_primitive
-    # TODO: Import Issue
-    # Java::JavaLang::NullPointerException:
-    #  org.jruby.ext.openssl.ASN1$Primitive.toDER(ASN1.java:1610)
-    #  org.jruby.ext.openssl.ASN1$ASN1Data.to_der(ASN1.java:1414)
-    #  org.jruby.ext.openssl.ASN1$Primitive.to_der(ASN1.java:1522)
-    #encode_test B(%w{ 00 00 }), OpenSSL::ASN1::Primitive.new(B(%w{}), 0)
-    # TODO: Import Issue
-    # <"\x01\x00"> expected but was <"\x01\x01\xFF">
-    #encode_test B(%w{ 01 00 }), OpenSSL::ASN1::Primitive.new(B(%w{}), 1, nil, :UNIVERSAL)
-    # <"\x81\x00"> expected but was <"\x01\x01\xFF">
-    #encode_test B(%w{ 81 00 }), OpenSSL::ASN1::Primitive.new(B(%w{}), 1, nil, :CONTEXT_SPECIFIC)
-    # <"\x01\x02\xAB\xCD"> expected but was <"\x01\x01\xFF">
-    #encode_test B(%w{ 01 02 AB CD }), OpenSSL::ASN1::Primitive.new(B(%w{ AB CD }), 1)
-    # <TypeError> exception was expected but none was thrown.
-    #assert_raise(TypeError) { OpenSSL::ASN1::Primitive.new([], 1).to_der }
+    encode_test B(%w{ 00 00 }), OpenSSL::ASN1::Primitive.new(B(%w{}), 0)
+    encode_test B(%w{ 01 00 }), OpenSSL::ASN1::Primitive.new(B(%w{}), 1, nil, :UNIVERSAL)
+    encode_test B(%w{ 81 00 }), OpenSSL::ASN1::Primitive.new(B(%w{}), 1, nil, :CONTEXT_SPECIFIC)
+    encode_test B(%w{ 01 02 AB CD }), OpenSSL::ASN1::Primitive.new(B(%w{ AB CD }), 1)
+    assert_raise(TypeError) { OpenSSL::ASN1::Primitive.new([], 1).to_der }
 
     prim = OpenSSL::ASN1::Integer.new(50)
     assert_equal false, prim.indefinite_length

--- a/src/test/ruby/test_asn1.rb
+++ b/src/test/ruby/test_asn1.rb
@@ -553,27 +553,19 @@ class TestASN1 < TestCase
   #
 
   def test_basic_constructed
-    #octet_string = OpenSSL::ASN1::OctetString.new(B(%w{ AB CD }))
-    # TODO: Import Issue
-    # OpenSSL::ASN1::ASN1Error: Constructive shall only be used with indefinite length
-    #encode_test B(%w{ 20 00 }), OpenSSL::ASN1::Constructive.new([], 0)
-    #encode_test B(%w{ 21 00 }), OpenSSL::ASN1::Constructive.new([], 1, nil, :UNIVERSAL)
-    #encode_test B(%w{ A1 00 }), OpenSSL::ASN1::Constructive.new([], 1, nil, :CONTEXT_SPECIFIC)
-    #encode_test B(%w{ 21 04 04 02 AB CD }), OpenSSL::ASN1::Constructive.new([octet_string], 1)
-    # Java::JavaLang::UnsupportedOperationException:
-    # #<OpenSSL::ASN1::Constructive:0x4fc256ec @tag=1, @value=[#<OpenSSL::ASN1::OctetString:0x7fc56d61
-    #   @tag=4, @value="\xAB\xCD", @tag_class=:UNIVERSAL, @tagging=nil, @indefinite_length=false>],
-    #   @tag_class=:CONTEXT_SPECIFIC, @tagging=:EXPLICIT, @indefinite_length=true>
-    #   org.jruby.ext.openssl.ASN1$Constructive.toDER(ASN1.java:1881)
-    #   org.jruby.ext.openssl.ASN1$ASN1Data.to_der(ASN1.java:1414)
-    #   org.jruby.ext.openssl.ASN1$Constructive.to_der(ASN1.java:1858)
-    #obj = OpenSSL::ASN1::Constructive.new([octet_string], 1)
-    #obj.indefinite_length = true
-    #encode_decode_test B(%w{ 21 80 04 02 AB CD 00 00 }), obj
-    # (see above) Java::JavaLang::UnsupportedOperationException
-    #obj = OpenSSL::ASN1::Constructive.new([octet_string, OpenSSL::ASN1::EndOfContent.new], 1)
-    #obj.indefinite_length = true
-    #encode_test B(%w{ 21 80 04 02 AB CD 00 00 }), obj
+    octet_string = OpenSSL::ASN1::OctetString.new(B(%w{ AB CD }))
+    encode_test B(%w{ 20 00 }), OpenSSL::ASN1::Constructive.new([], 0)
+    encode_test B(%w{ 21 00 }), OpenSSL::ASN1::Constructive.new([], 1, nil, :UNIVERSAL)
+    encode_test B(%w{ A1 00 }), OpenSSL::ASN1::Constructive.new([], 1, nil, :CONTEXT_SPECIFIC)
+    encode_test B(%w{ 21 04 04 02 AB CD }), OpenSSL::ASN1::Constructive.new([octet_string], 1)
+    obj = OpenSSL::ASN1::Constructive.new([octet_string], 1)
+    obj.indefinite_length = true
+    encode_test B(%w{ 21 80 04 02 AB CD 00 00 }), obj
+    # TODO: BC doesn't support decoding indef constructive asn1s from unsupported tag types.
+    # encode_decode_test B(%w{ 21 80 04 02 AB CD 00 00 }), obj
+    obj = OpenSSL::ASN1::Constructive.new([octet_string, OpenSSL::ASN1::EndOfContent.new], 1)
+    obj.indefinite_length = true
+    encode_test B(%w{ 21 80 04 02 AB CD 00 00 }), obj
   end
 
   def test_constructive


### PR DESCRIPTION
To atest some of the improvements of this PR, some encode/decode tests from the ruby-openssl repo were imported (which have been previously commented out).

In broad strokes, the main fixes/improvements from this changeset:

* Raw ASN1Data objects with array values can now be encoded/decoded.
* Improved support for indefinite length `Constructive` **and** raw `ASN1Data` objects (the checks around EndOfContent elements were ported from the `ruby-openssl` repo)
* Imported upstream check to avoid encoding indifinite length objects with a non-array value.
* initialization of `Primitive` objects was incorrect, it is now matching what upstream does
  * I contributed a rewrite in ruby of this logic to `ruby-openssl`, which `jruby-openssl` could also benefit of, but I don't think it's worth atm to just copy code around, more on that later.
* fixed internal `isEOC` check to take into account raw `ASN1Data` objects which "quack" like an `EndOfContent`
* `Primitive` objects with an OOTB-unsupported type will now raise an error **if** the value can't be encoded into a string (same as upstream).


I have more detailed information in each commit message, if you prefer that method of review. There were two tests I wasn't able to port, as making them work would require to adapt even more code from BC than I already did here, so I'll leave those for some other time.

On a separate note, it'd be really cool if [this](https://github.com/ruby/openssl/issues/20) could be taken into the finish line. It seems that it's hanging on licensing issues, and I don't know how hard it'd be to coalesce licenses, but besides the usual code copying churn and ability to track what's and what's not supported, I've been trying to lobby for more ruby in the source code ([here](https://github.com/ruby/openssl/pull/740) and [here](https://github.com/ruby/openssl/pull/777)), which would benefit both implementations, but it's hard to do it across multiple repos. 

cc @kares @headius 