### PR TITLE
Encode Netscape IA5String extensions correctly

### DIFF
--- a/src/main/java/org/jruby/ext/openssl/X509ExtensionFactory.java
+++ b/src/main/java/org/jruby/ext/openssl/X509ExtensionFactory.java
@@ -211,6 +211,9 @@ public class X509ExtensionFactory extends RubyObject {
             else if (id.equals("1.3.6.1.5.5.7.1.1")) { // authorityInfoAccess
                 value = parseAuthorityInfoAccess(valuex);
             }
+            else if (isNetscapeIA5StringExtension(id)) {
+                value = new DEROctetString(new DERIA5String(valuex).getEncoded(ASN1Encoding.DER));
+            }
             else {
                 value = new DEROctetString(new DEROctetString(ByteList.plain(valuex)).getEncoded(ASN1Encoding.DER));
             }
@@ -383,6 +386,25 @@ public class X509ExtensionFactory extends RubyObject {
             unused += x;
         }
         return new DERBitString(new byte[]{v}, unused);
+    }
+
+    /**
+     * Returns true for Netscape extensions whose value is an IA5String.
+     * nsCertType (2.16.840.1.113730.1.1) is a BIT STRING handled separately.
+     */
+    private static boolean isNetscapeIA5StringExtension(final String oid) {
+        switch (oid) {
+            case "2.16.840.1.113730.1.2":  // nsBaseUrl
+            case "2.16.840.1.113730.1.3":  // nsRevocationUrl
+            case "2.16.840.1.113730.1.4":  // nsCaRevocationUrl
+            case "2.16.840.1.113730.1.7":  // nsRenewalUrl
+            case "2.16.840.1.113730.1.8":  // nsCaPolicyUrl
+            case "2.16.840.1.113730.1.12": // nsSslServerName
+            case "2.16.840.1.113730.1.13": // nsComment
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static DLSequence parseBasicConstrains(final String valuex) {

--- a/src/test/ruby/x509/test_x509ext.rb
+++ b/src/test/ruby/x509/test_x509ext.rb
@@ -331,6 +331,30 @@ class TestX509Extension < TestCase
     assert_equal "DNS:test.example.com, DNS:test2.example.com, DNS:example.com, DNS:www.example.com", ext.value
   end
 
+  def test_ns_comment_der_encoding
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ext = ef.create_extension("nsComment", "my test comment")
+
+    # Value round-trips correctly
+    assert_equal "my test comment", ext.value
+
+    # Inner encoding must be IA5String (tag 0x16), not OCTET STRING (tag 0x04)
+    seq = OpenSSL::ASN1.decode(ext.to_der)
+    inner = OpenSSL::ASN1.decode(seq.value[-1].value)
+    assert_instance_of OpenSSL::ASN1::IA5String, inner
+    assert_equal "my test comment", inner.value
+  end
+
+  def test_ns_base_url_der_encoding
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ext = ef.create_extension("nsBaseUrl", "https://example.com/")
+
+    seq = OpenSSL::ASN1.decode(ext.to_der)
+    inner = OpenSSL::ASN1.decode(seq.value[-1].value)
+    assert_instance_of OpenSSL::ASN1::IA5String, inner
+    assert_equal "https://example.com/", inner.value
+  end
+
   def subject_alt_name(domains)
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.create_extension("subjectAltName", domains.split(',').map { |d| "DNS: #{d}" }.join(', '))


### PR DESCRIPTION
## Summary

`X509ExtensionFactory#create_ext` has no special case for `nsComment` (OID `2.16.840.1.113730.1.13`) and other Netscape IA5String extensions. They fall through to the generic `else` branch which double-wraps the value in OCTET STRINGs:

```
OCTET STRING { OCTET STRING { raw ASCII } }   -- JRuby (broken)
OCTET STRING { IA5String "..." }               -- CRuby (correct)
```

This causes BouncyCastle to crash when parsing certificates containing these extensions:

```
java.io.IOException: corrupted stream - out of bounds length found: 117 >= 34
```

## Changes

- Add `isNetscapeIA5StringExtension()` covering all Netscape extensions defined as IA5String: `nsBaseUrl`, `nsRevocationUrl`, `nsCaRevocationUrl`, `nsRenewalUrl`, `nsCaPolicyUrl`, `nsSslServerName`, `nsComment`
- `nsCertType` (BIT STRING) is excluded as it is already handled separately
- Add tests verifying IA5String encoding for `nsComment` and `nsBaseUrl`

## How to reproduce

```ruby
require 'openssl'

ef = OpenSSL::X509::ExtensionFactory.new
ext = ef.create_extension('nsComment', 'Puppet Server Internal Certificate', false)
puts ext.to_der.bytes.map { |b| '%02x' % b }.join(' ')
```

- CRuby: inner bytes start with `16 22` (IA5String tag + length)
- JRuby: inner bytes start with `04 28` (OCTET STRING tag + length)

Fixes https://github.com/jruby/jruby-openssl/issues/349