### PR TITLE
Avoid direct constructors from JRuby

### DIFF
--- a/Mavenfile
+++ b/Mavenfile
@@ -82,7 +82,7 @@ plugin :clean do
                  'failOnError' =>  'false' )
 end
 
-jar 'org.jruby:jruby-core', '9.2.0.0', :scope => :provided
+jar 'org.jruby:jruby-core', '9.2.1.0', :scope => :provided
 # for invoker generated classes we need to add javax.annotation when on Java > 8
 jar 'javax.annotation:javax.annotation-api', '1.3.1', :scope => :compile
 jar 'org.junit.jupiter:junit-jupiter', '5.11.4', :scope => :test

--- a/src/main/java/org/jruby/ext/openssl/StringHelper.java
+++ b/src/main/java/org/jruby/ext/openssl/StringHelper.java
@@ -63,7 +63,7 @@ abstract class StringHelper {
     }
 
     static RubyString newString(final Ruby runtime, final CharSequence chars) {
-        return new RubyString(runtime, runtime.getString(), chars, ASCIIEncoding.INSTANCE);
+        return RubyString.newString(runtime, chars, ASCIIEncoding.INSTANCE);
     }
 
     static ByteList setByteListShared(final RubyString str) {
@@ -73,12 +73,12 @@ abstract class StringHelper {
 
     static RubyString newUTF8String(final Ruby runtime, final ByteList bytes) {
         ByteList byteList = new ByteList(RubyEncoding.encodeUTF8(bytes), UTF8Encoding.INSTANCE, false);
-        return new RubyString(runtime, runtime.getString(), byteList);
+        return RubyString.newString(runtime, byteList);
     }
 
     static RubyString newUTF8String(final Ruby runtime, final CharSequence chars) {
         ByteList byteList = new ByteList(RubyEncoding.encodeUTF8(chars), UTF8Encoding.INSTANCE, false);
-        return new RubyString(runtime, runtime.getString(), byteList);
+        return RubyString.newString(runtime, byteList);
     }
 
     static RubyString newStringFrozen(final Ruby runtime, final ByteList bytes) {


### PR DESCRIPTION
The string class will be made abstract in the future. We should avoid using the direct constructors from now on.