### PR TITLE
[deps] upgrade BC to version 1.84

### DIFF
--- a/Mavenfile
+++ b/Mavenfile
@@ -109,7 +109,7 @@ supported_bc_versions = %w{ 1.78 1.79 1.80 1.81 1.82 1.83 1.84 }
 default_bc_version = File.read File.expand_path('lib/jopenssl/version.rb', File.dirname(__FILE__))
 default_bc_version = default_bc_version[/BOUNCY_CASTLE_VERSION\s?=\s?'(.*?)'/, 1]
 
-properties( 'jruby.plugins.version' => '3.0.2',
+properties( 'jruby.plugins.version' => '3.0.6',
             'jruby.switches' => '-W0', # https://github.com/torquebox/jruby-maven-plugins/issues/94
             'bc.versions' => default_bc_version,
             'invoker.test' => '${bc.versions}',
@@ -118,7 +118,7 @@ properties( 'jruby.plugins.version' => '3.0.2',
             'skipRunit' => 'true',
             'runit.dir' => 'src/test/ruby/**/test_*.rb',
             'mavengem.wagon.version' => '2.0.2', # for jruby plugin
-            'mavengem-wagon.version' => '2.0.2', # for polyglot-ruby
+            'mavengem-wagon.version' => '3.0.0', # for polyglot-ruby
             # use this version of jruby for the jruby-maven-plugins
             'jruby.versions' => MVN_JRUBY_VERSION, 'jruby.version' => MVN_JRUBY_VERSION,
             # dump pom.xml when running 'rmvn'

--- a/Mavenfile
+++ b/Mavenfile
@@ -104,7 +104,7 @@ plugin :deploy, '3.1.4' do
   execute_goals( :deploy, :skip => false )
 end
 
-supported_bc_versions = %w{ 1.78 1.79 1.80 1.81 1.82 1.83 }
+supported_bc_versions = %w{ 1.78 1.79 1.80 1.81 1.82 1.83 1.84 }
 
 default_bc_version = File.read File.expand_path('lib/jopenssl/version.rb', File.dirname(__FILE__))
 default_bc_version = default_bc_version[/BOUNCY_CASTLE_VERSION\s?=\s?'(.*?)'/, 1]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the JRuby [mailing list][1] or the [bug tracker][2].
 | ~>0.12.x      | 9.1.x-9.3.x  |  Java 8-15 |    1.65-1.68 |
 | ~>0.13.x      | 9.1.x-9.4.x  |  Java 8-17 |    1.68-1.69 |
 | ~>0.14.x      | 9.1.x-9.4.x  |  Java 8-21 |    1.71-1.74 |
-| ~>0.15.x      | 9.2.x-10.0.x |  Java 8-25 |    1.78-1.83 |
+| ~>0.15.x      | 9.2.x-10.0.x |  Java 8-25 |    1.78-1.84 |
 
 NOTE: backwards JRuby compatibility was not handled for versions <= **0.9.6**
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ Rake::TestTask.new do |task|
   test_files = FileList['src/test/ruby/**/test*.rb'].to_a
   task.test_files = test_files.map { |path| path.sub('src/test/ruby/', '') }
   task.verbose = true
-  task.loader = :direct
+  task.loader = "ARGV.each { |f| require f unless f.start_with?('-') }"
   task.ruby_opts = [ '-C', 'src/test/ruby', '-rbundler/setup' ]
 end
 task :test => 'lib/jopenssl.jar'
@@ -49,7 +49,7 @@ namespace :integration do
     unless File.exist?(File.join(it_path, 'Gemfile.lock'))
       raise "bundle not installed, run `rake integration:install'"
     end
-    loader = "ARGV.each { |f| require f }"
+    loader = "ARGV.each { |f| require f unless f.start_with?('-') }"
     lib = [ File.expand_path('../lib', __FILE__), it_path ]
     test_files = FileList['src/test/integration/*_test.rb'].map { |path| path.sub('src/test/integration/', '') }
     ruby "-I#{lib.join(':')} -C src/test/integration -e \"#{loader}\" #{test_files.map { |f| "\"#{f}\"" }.join(' ')}"

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -38,7 +38,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <executions>
@@ -97,7 +97,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>runit-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <executions>

--- a/lib/jopenssl/version.rb
+++ b/lib/jopenssl/version.rb
@@ -1,6 +1,6 @@
 module JOpenSSL
   VERSION = '0.15.8.dev'
-  BOUNCY_CASTLE_VERSION = '1.83'
+  BOUNCY_CASTLE_VERSION = '1.84'
 end
 
 Object.class_eval do

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ DO NOT MODIFY - GENERATED CODE
     </snapshotRepository>
   </distributionManagement>
   <properties>
-    <bc.versions>1.83</bc.versions>
+    <bc.versions>1.84</bc.versions>
     <invoker.skip>${maven.test.skip}</invoker.skip>
     <invoker.test>${bc.versions}</invoker.test>
     <jruby.plugins.version>3.0.2</jruby.plugins.version>
@@ -78,22 +78,22 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>1.84</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>1.84</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>1.84</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>1.84</version>
     </dependency>
     <dependency>
       <groupId>org.jruby</groupId>
@@ -407,7 +407,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>9.2.19.0</jruby.version>
         <jruby.versions>9.2.19.0</jruby.versions>
       </properties>
@@ -445,7 +445,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>9.2.20.1</jruby.version>
         <jruby.versions>9.2.20.1</jruby.versions>
       </properties>
@@ -483,7 +483,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>9.3.3.0</jruby.version>
         <jruby.versions>9.3.3.0</jruby.versions>
       </properties>
@@ -521,7 +521,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>9.3.13.0</jruby.version>
         <jruby.versions>9.3.13.0</jruby.versions>
       </properties>
@@ -559,7 +559,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>9.4.8.0</jruby.version>
         <jruby.versions>9.4.8.0</jruby.versions>
       </properties>
@@ -597,7 +597,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>9.4.14.0</jruby.version>
         <jruby.versions>9.4.14.0</jruby.versions>
       </properties>
@@ -635,7 +635,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugins>
       </build>
       <properties>
-        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83</bc.versions>
+        <bc.versions>1.78,1.79,1.80,1.81,1.82,1.83,1.84</bc.versions>
         <jruby.version>10.0.2.0</jruby.version>
         <jruby.versions>10.0.2.0</jruby.versions>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@ DO NOT MODIFY - GENERATED CODE
     <bc.versions>1.84</bc.versions>
     <invoker.skip>${maven.test.skip}</invoker.skip>
     <invoker.test>${bc.versions}</invoker.test>
-    <jruby.plugins.version>3.0.2</jruby.plugins.version>
+    <jruby.plugins.version>3.0.6</jruby.plugins.version>
     <jruby.switches>-W0</jruby.switches>
     <jruby.version>9.2.19.0</jruby.version>
     <jruby.versions>9.2.19.0</jruby.versions>
-    <mavengem-wagon.version>2.0.2</mavengem-wagon.version>
-    <mavengem.wagon.version>2.0.2</mavengem.wagon.version>
+    <mavengem.wagon.version>2.0.2</mavengem.wagon.version> <!-- for jruby plugin -->
+    <mavengem-wagon.version>3.0.0</mavengem-wagon.version> <!-- for polyglot-ruby -->
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>false</polyglot.dump.readonly>
     <runit.dir>src/test/ruby/**/test_*.rb</runit.dir>

--- a/src/main/java/org/jruby/ext/openssl/impl/PKey.java
+++ b/src/main/java/org/jruby/ext/openssl/impl/PKey.java
@@ -297,7 +297,7 @@ public class PKey {
             org.bouncycastle.asn1.sec.ECPrivateKey key = org.bouncycastle.asn1.sec.ECPrivateKey.getInstance(seq);
             AlgorithmIdentifier algId = keyInfo.getPrivateKeyAlgorithm();
             if (algId == null) { // mockPrivateKeyInfo
-                algId = new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, key.getParameters());
+                algId = new AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, key.getParametersObject().toASN1Primitive());
             }
             final PrivateKeyInfo privInfo = new PrivateKeyInfo(algId, key);
             ECPrivateKey privateKey = (ECPrivateKey) keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privInfo.getEncoded()));

--- a/src/test/ruby/test_helper.rb
+++ b/src/test/ruby/test_helper.rb
@@ -52,7 +52,7 @@ begin
 rescue LoadError => e
   warn "gem 'minitest' failed to load: #{e.inspect}"
 end unless (Test::Unit::AutoRunner.respond_to?(:setup_option)) rescue true # runit rules
-# @see https://github.com/torquebox/jruby-maven-plugins/blob/master/runit-maven-plugin/src/main/java/de/saumya/mojo/runit/RunitMavenTestScriptFactory.java
+# @see https://github.com/jruby/jruby-maven-plugins/blob/master/runit-maven-plugin/src/main/java/de/saumya/mojo/runit/RunitMavenTestScriptFactory.java
 
 if defined? Minitest::Test
   TestCase = Minitest::Test


### PR DESCRIPTION
Replaces #357 and #359

https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-84

Fixes a number of CVEs which may or may not affect JRuby, but cause scanner noise all the same.
- CVE-2025-14813 - GOSTCTR implementation unable to process more than 255 blocks correctly.
- CVE-2026-0636 - LDAP Injection Vulnerability in LDAPStoreHelper.java.
- CVE-2026-3505 - Unbounded PGP AEAD chunk size leads to pre-auth resource exhaustion.
- CVE-2026-5588 - PKIX draft CompositeVerifier accepts empty signature sequence as valid.
- CVE-2026-5598 - Non-constant time comparisons risk private key leakage in FrodoKEM.